### PR TITLE
Add weekly Monday automation + expand to 666 recipients

### DIFF
--- a/job-outreach/.gitignore
+++ b/job-outreach/.gitignore
@@ -2,6 +2,7 @@
 .env
 sent_log.csv
 run_daily.log
+run_weekly.log
 run_*.log
 whatsapp_links.html
 *.local

--- a/job-outreach/README.md
+++ b/job-outreach/README.md
@@ -111,6 +111,37 @@ Add this line to run every day at 10:00 AM (use the full path to the file):
 
 Output of each run is appended to `run_daily.log` in this folder.
 
+### Weekly automation — every Monday at 12:00 noon (run for years)
+
+Use `run_weekly.sh` / `run_weekly.bat` for a hands-off weekly pipeline. It does
+**not** spam the same people — de-dupe is always on. Each Monday it emails any
+**new** companies you've added, sends **limited follow-ups** (max 2 per contact)
+to non-responders, and records replies/bounces.
+
+**Linux / macOS (cron) — every Monday 12:00:**
+```bash
+chmod +x run_weekly.sh
+crontab -e
+```
+Add (use the full path):
+```
+0 12 * * 1 /full/path/to/job-outreach/run_weekly.sh
+```
+`* * 1` = Monday, `0 12` = 12:00 noon. Leave it in your crontab and it keeps
+running every Monday for as long as you like (years) — just keep your computer
+on at that time and add new targets over time.
+
+**Windows (Task Scheduler):** Create Task → Trigger: **Weekly → Monday → 12:00 PM**
+→ Action: run `run_weekly.bat`. Set it to repeat weekly with no end date.
+
+> WHY NOT re-send the same email to everyone every week? Sending the identical
+> application to the same companies repeatedly is spam: Gmail will rate-limit and
+> eventually ban the account, and recruiters will blacklist the sender. The weekly
+> job therefore targets only NEW companies plus a small, capped number of polite
+> follow-ups. To keep getting value over months/years, keep adding fresh targets.
+
+Output is appended to `run_weekly.log`.
+
 ## Useful options
 
 ```bash

--- a/job-outreach/run_weekly.bat
+++ b/job-outreach/run_weekly.bat
@@ -1,0 +1,28 @@
+@echo off
+REM ====================================================================
+REM  WEEKLY job-application runner  (Windows)
+REM  Schedule in Task Scheduler: Weekly, every Monday at 12:00 noon.
+REM
+REM  NOT a spam loop - de-dupe is always on, so people already
+REM  contacted are never re-emailed. Each week it:
+REM    1. detects replies & bounces
+REM    2. emails any NEW companies added to recipients.csv
+REM    3. sends limited follow-ups (max 2) to non-responders
+REM    4. prints a report
+REM  Credentials come from the .env file in this folder.
+REM ====================================================================
+cd /d "%~dp0"
+set LOG=run_weekly.log
+
+echo. >> "%LOG%"
+echo ================================================== >> "%LOG%"
+echo Weekly run started: %date% %time% >> "%LOG%"
+echo ================================================== >> "%LOG%"
+
+python check_replies.py --apply >> "%LOG%" 2>&1
+python send_applications.py --send --limit 120 >> "%LOG%" 2>&1
+python send_applications.py --followup --send --followup-after 7 --max-followups 2 >> "%LOG%" 2>&1
+python send_applications.py --report >> "%LOG%" 2>&1
+
+echo Weekly run finished: %date% %time% >> "%LOG%"
+echo Weekly run complete. Full output in: %cd%\%LOG%

--- a/job-outreach/run_weekly.sh
+++ b/job-outreach/run_weekly.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# ====================================================================
+#  WEEKLY job-application runner  (Linux / macOS)
+#  Designed for a cron schedule of: every Monday at 12:00 noon.
+#
+#  IMPORTANT - this is NOT a spam loop. It will NOT re-send the same
+#  application to people already contacted (de-dupe is always on).
+#  Each week it:
+#    1. detects replies & bounces (so they are skipped going forward)
+#    2. emails any NEW companies added to recipients.csv / Google Sheet
+#    3. sends a LIMITED follow-up (max 2 per contact) to non-responders
+#       who were emailed 7+ days ago and have not replied/bounced
+#    4. prints a status report
+#
+#  Re-sending the identical email to the same companies every week
+#  would be spam and would get the Gmail account banned, so it is
+#  intentionally prevented. Add NEW targets to keep the pipeline fresh.
+#
+#  Credentials are read from the .env file in this folder.
+# ====================================================================
+set -uo pipefail
+cd "$(dirname "$0")"
+
+LOG="run_weekly.log"
+{
+  echo ""
+  echo "=================================================="
+  echo "Weekly run started: $(date)"
+  echo "=================================================="
+
+  echo "--- [1/4] checking replies & bounces ---"
+  python3 check_replies.py --apply || echo "(reply-check skipped/failed)"
+
+  echo "--- [2/4] emailing NEW companies (de-duped, daily cap) ---"
+  python3 send_applications.py --send --limit 120 || echo "(send skipped/failed)"
+
+  echo "--- [3/4] limited follow-ups (7+ days, max 2 per contact) ---"
+  python3 send_applications.py --followup --send --followup-after 7 --max-followups 2 \
+      || echo "(follow-up skipped/failed)"
+
+  echo "--- [4/4] status report ---"
+  python3 send_applications.py --report || true
+
+  echo "Weekly run finished: $(date)"
+} >> "$LOG" 2>&1
+
+echo "Weekly run complete. Full output in: $(pwd)/$LOG"
+tail -n 25 "$LOG"


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @balajirajput96 :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro Web](https://kiro.dev/web/)</sub>

---
## Weekly automation + 666 recipients

Single commit on top of the job-outreach toolkit branch.

### Added
- **run_weekly.sh / run_weekly.bat** — every-Monday-12:00-noon pipeline: detect replies/bounces, email NEW companies, send limited follow-ups (max 2 per contact), print report.
- **README** — cron + Windows Task Scheduler setup for running weekly for years, with an explicit note on why re-sending the same email to the same people weekly is spam (and is intentionally prevented).
- **recipients.csv** — expanded to 666 unique pharma HR/careers emails (pan-India + international CDMO/CRO).

### Safety
- De-dupe always on — already-contacted addresses are never re-emailed.
- Follow-ups capped at 2 per contact.
- Former employer (Elysium) hard-blocked.

### Note on "5-year / weekly to everyone"
Re-sending the identical application to the same companies every week would be spam and would get the Gmail account banned. The weekly job instead targets NEW companies + capped follow-ups, which is safe to run for years.