### PR TITLE
Job-outreach toolkit + weekly automation (954 recipients) — rebase-safe

### DIFF
--- a/job-outreach/run_weekly.bat
+++ b/job-outreach/run_weekly.bat
@@ -1,0 +1,28 @@
+@echo off
+REM ====================================================================
+REM  WEEKLY job-application runner  (Windows)
+REM  Schedule in Task Scheduler: Weekly, every Monday at 12:00 noon.
+REM
+REM  NOT a spam loop - de-dupe is always on, so people already
+REM  contacted are never re-emailed. Each week it:
+REM    1. detects replies & bounces
+REM    2. emails any NEW companies added to recipients.csv
+REM    3. sends limited follow-ups (max 2) to non-responders
+REM    4. prints a report
+REM  Credentials come from the .env file in this folder.
+REM ====================================================================
+cd /d "%~dp0"
+set LOG=run_weekly.log
+
+echo. >> "%LOG%"
+echo ================================================== >> "%LOG%"
+echo Weekly run started: %date% %time% >> "%LOG%"
+echo ================================================== >> "%LOG%"
+
+python check_replies.py --apply >> "%LOG%" 2>&1
+python send_applications.py --send --limit 120 >> "%LOG%" 2>&1
+python send_applications.py --followup --send --followup-after 7 --max-followups 2 >> "%LOG%" 2>&1
+python send_applications.py --report >> "%LOG%" 2>&1
+
+echo Weekly run finished: %date% %time% >> "%LOG%"
+echo Weekly run complete. Full output in: %cd%\%LOG%

--- a/job-outreach/run_weekly.sh
+++ b/job-outreach/run_weekly.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# ====================================================================
+#  WEEKLY job-application runner  (Linux / macOS)
+#  Designed for a cron schedule of: every Monday at 12:00 noon.
+#
+#  IMPORTANT - this is NOT a spam loop. It will NOT re-send the same
+#  application to people already contacted (de-dupe is always on).
+#  Each week it:
+#    1. detects replies & bounces (so they are skipped going forward)
+#    2. emails any NEW companies added to recipients.csv / Google Sheet
+#    3. sends a LIMITED follow-up (max 2 per contact) to non-responders
+#       who were emailed 7+ days ago and have not replied/bounced
+#    4. prints a status report
+#
+#  Re-sending the identical email to the same companies every week
+#  would be spam and would get the Gmail account banned, so it is
+#  intentionally prevented. Add NEW targets to keep the pipeline fresh.
+#
+#  Credentials are read from the .env file in this folder.
+# ====================================================================
+set -uo pipefail
+cd "$(dirname "$0")"
+
+LOG="run_weekly.log"
+{
+  echo ""
+  echo "=================================================="
+  echo "Weekly run started: $(date)"
+  echo "=================================================="
+
+  echo "--- [1/4] checking replies & bounces ---"
+  python3 check_replies.py --apply || echo "(reply-check skipped/failed)"
+
+  echo "--- [2/4] emailing NEW companies (de-duped, daily cap) ---"
+  python3 send_applications.py --send --limit 120 || echo "(send skipped/failed)"
+
+  echo "--- [3/4] limited follow-ups (7+ days, max 2 per contact) ---"
+  python3 send_applications.py --followup --send --followup-after 7 --max-followups 2 \
+      || echo "(follow-up skipped/failed)"
+
+  echo "--- [4/4] status report ---"
+  python3 send_applications.py --report || true
+
+  echo "Weekly run finished: $(date)"
+} >> "$LOG" 2>&1
+
+echo "Weekly run complete. Full output in: $(pwd)/$LOG"
+tail -n 25 "$LOG"


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @balajirajput96 :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro Web](https://kiro.dev/web/)</sub>

---
## Single commit — rebase merge now works (replaces #38 and all earlier PRs)

Exactly **1 commit** on top of current `main`. Fast-forward, zero conflict — Rebase / Squash / Merge all work.

**Why #38 rebase failed:** it had multiple stacked commits + binary PDF changes GitHub couldn't cleanly replay. Squashing to one commit fixes it.

**After merging, close PRs #26–#39.**

### Contents
- Resume: fixed PDF bookmarks + underlined links.
- job-outreach/ toolkit (pure Python stdlib): QA-focused personalized email sender (2-yr QA/IPQA experience, resume attached), follow-ups, status report, IMAP reply/bounce detection, daily + weekly (Monday 12:00) schedulers, Google Sheet support.
- **954 unique** pharma HR/careers recipients.
- companies_to_apply.csv, copy_paste_messages.md, whatsapp_links.py, templates, README.

### Safety
- De-dupe always on. Follow-ups capped at 2. Former employer (Elysium) hard-blocked (verified never contacted).