### PR TITLE
Free job-automation MVP (GitHub Actions + Google Sheets, human-in-the-loop)

### DIFF
--- a/.github/workflows/daily-jobs.yml
+++ b/.github/workflows/daily-jobs.yml
@@ -1,0 +1,34 @@
+name: Daily Pharma Job Scan
+
+on:
+  schedule:
+    - cron: "30 3 * * *"   # 09:00 IST daily (03:30 UTC)
+  workflow_dispatch: {}     # allows manual "Run workflow" button
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: job-outreach/automation
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run daily scan (fetch -> extract -> score -> draft -> write)
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          GOOGLE_SA_JSON: ${{ secrets.GOOGLE_SA_JSON }}
+          SHEET_ID: ${{ secrets.SHEET_ID }}
+          LLM_MODEL: openai/gpt-4o-mini
+          SCORE_THRESHOLD: "55"
+        run: python run.py

--- a/.github/workflows/daily-jobs.yml
+++ b/.github/workflows/daily-jobs.yml
@@ -2,11 +2,11 @@ name: Daily Pharma Job Scan
 
 on:
   schedule:
-    - cron: "30 3 * * *"   # 09:00 IST daily (03:30 UTC)
-  workflow_dispatch: {}     # allows manual "Run workflow" button
+    - cron: "30 3 * * *"     # 09:00 IST daily
+  workflow_dispatch: {}       # manual "Run workflow" button
 
 permissions:
-  contents: read
+  contents: write             # allow committing jobs.csv + dashboard.md back
 
 jobs:
   scan:
@@ -24,11 +24,17 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt
 
-      - name: Run daily scan (fetch -> extract -> score -> draft -> write)
+      - name: Run daily scan (fetch -> extract -> score -> draft -> dashboard)
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-          GOOGLE_SA_JSON: ${{ secrets.GOOGLE_SA_JSON }}
-          SHEET_ID: ${{ secrets.SHEET_ID }}
           LLM_MODEL: openai/gpt-4o-mini
           SCORE_THRESHOLD: "55"
-        run: python run.py
+        run: python run_repo.py
+
+      - name: Commit results
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add jobs.csv dashboard.md
+          git diff --staged --quiet || git commit -m "chore: daily job scan update"
+          git push

--- a/job-outreach/automation/.env.example
+++ b/job-outreach/automation/.env.example
@@ -1,0 +1,10 @@
+# Copy to .env for LOCAL testing only. NEVER commit the real .env.
+# In production these come from GitHub Actions Secrets (repo Settings -> Secrets).
+
+OPENROUTER_API_KEY=your_new_openrouter_key_here
+GOOGLE_SA_JSON={"type":"service_account", "...": "paste full service-account JSON here"}
+SHEET_ID=your_google_sheet_id_here
+
+# Optional
+LLM_MODEL=openai/gpt-4o-mini
+SCORE_THRESHOLD=55

--- a/job-outreach/automation/README.md
+++ b/job-outreach/automation/README.md
@@ -1,12 +1,33 @@
-# Pharma QA/IPQA Job Automation — MVP (GitHub Actions + Google Sheets)
+# Pharma QA/IPQA Job Automation — MVP (GitHub Actions)
 
 Free, no-server, compliant, human-in-the-loop job-application system.
 
-- Runs **daily** on GitHub Actions (cron) — no server needed.
-- Reads job URLs you paste into a Google Sheet **Inbox** tab (+ optional RSS feeds).
-- Uses an LLM to **extract → score → draft** email / LinkedIn / follow-ups.
-- Writes ranked results back into the Sheet (your dashboard).
-- **Never sends anything.** You review, approve, and send yourself (compliant, ban-safe).
+## ⭐ RECOMMENDED: Zero-Google setup (only 1 secret, least work)
+Uses the repo itself as the database — **no Google account needed.**
+
+**One-time (2 minutes):**
+1. Get a NEW OpenRouter key: https://openrouter.ai/keys
+2. Repo → Settings → Secrets and variables → Actions → New secret:
+   - Name: `OPENROUTER_API_KEY`  Value: your new key
+3. Actions tab → enable workflows → open "Daily Pharma Job Scan" → **Run workflow** (test).
+
+**Daily (10 seconds):**
+- Open `job-outreach/automation/inbox.txt` on GitHub (pencil icon) → paste job URLs
+  (LinkedIn/Naukri/Indeed/career pages) → commit.
+- The daily run reads them and updates:
+  - `dashboard.md` → ranked Top-10 matches + walk-ins + ready-to-send drafts
+  - `jobs.csv`     → full tracker (with status column)
+- You review `dashboard.md`, copy a draft, and **send it yourself** (nothing auto-sends).
+
+That's the whole system. `run_repo.py` + `.github/workflows/daily-jobs.yml` do the rest.
+
+---
+
+## Alternative: Google Sheets dashboard (optional)
+If you prefer a live spreadsheet dashboard instead of files in the repo, use `run.py`
+with a Google Sheet. This needs a Google service account (more setup). Steps below.
+
+
 
 ## What is automated vs manual
 | Automated (daily, hands-off) | Manual (you, ~5–10 min/day) |

--- a/job-outreach/automation/README.md
+++ b/job-outreach/automation/README.md
@@ -19,8 +19,9 @@ Free, no-server, compliant, human-in-the-loop job-application system.
 
 ## One-time setup (≈30 min)
 ### 1. Create the Google Sheet
-- New Google Sheet named `Pharma-Job-Tracker`.
-- Create tabs exactly: `Inbox`, `Jobs`, `Summary` (columns in `sheet_schema.md`).
+- Create a new blank Google Sheet named `Pharma-Job-Tracker`.
+- That's it — the workflow **auto-creates** the `Inbox`, `Jobs`, `Summary` tabs and
+  headers on first run. (Schema reference: `sheet_schema.md`.)
 - Copy its **Sheet ID** (from the URL between `/d/` and `/edit`).
 
 ### 2. Google service account (free)

--- a/job-outreach/automation/README.md
+++ b/job-outreach/automation/README.md
@@ -1,0 +1,56 @@
+# Pharma QA/IPQA Job Automation — MVP (GitHub Actions + Google Sheets)
+
+Free, no-server, compliant, human-in-the-loop job-application system.
+
+- Runs **daily** on GitHub Actions (cron) — no server needed.
+- Reads job URLs you paste into a Google Sheet **Inbox** tab (+ optional RSS feeds).
+- Uses an LLM to **extract → score → draft** email / LinkedIn / follow-ups.
+- Writes ranked results back into the Sheet (your dashboard).
+- **Never sends anything.** You review, approve, and send yourself (compliant, ban-safe).
+
+## What is automated vs manual
+| Automated (daily, hands-off) | Manual (you, ~5–10 min/day) |
+|---|---|
+| Fetch job pages you queued | Paste new job/saved-search URLs into **Inbox** tab |
+| Extract structured fields (AI) | Review **Top matches** |
+| Score match vs your profile (AI) | Set status `approved` on good ones |
+| Draft email + LinkedIn + follow-ups (AI) | Copy the draft and **send it yourself** |
+| Dedupe + write to Sheet + daily summary | Attach your resume when sending |
+
+## One-time setup (≈30 min)
+### 1. Create the Google Sheet
+- New Google Sheet named `Pharma-Job-Tracker`.
+- Create tabs exactly: `Inbox`, `Jobs`, `Summary` (columns in `sheet_schema.md`).
+- Copy its **Sheet ID** (from the URL between `/d/` and `/edit`).
+
+### 2. Google service account (free)
+- console.cloud.google.com → new project → enable **Google Sheets API**.
+- Create a **Service Account** → create a JSON key → download it.
+- **Share your Sheet** with the service account's email (Editor).
+
+### 3. Get a NEW LLM key
+- Use OpenRouter (openrouter.ai/keys) — create a **fresh** key.
+- (Any key you ever pasted in chat/DM must be revoked and recreated.)
+
+### 4. Add GitHub Secrets  (repo → Settings → Secrets and variables → Actions)
+- `OPENROUTER_API_KEY`   = your new OpenRouter key
+- `GOOGLE_SA_JSON`       = full contents of the service-account JSON
+- `SHEET_ID`             = your Google Sheet ID
+> Secrets live ONLY here. They are never written to code or committed.
+
+### 5. Enable the workflow
+- The workflow file is at `.github/workflows/daily-jobs.yml`.
+- Actions tab → enable workflows → run once manually to test.
+
+## Daily use
+1. Paste any new job / LinkedIn saved-search / career-page URLs into the **Inbox** tab.
+2. The daily run fills the **Jobs** tab (ranked) with ready drafts.
+3. Open **Summary** → pick good matches → set status `approved` → copy draft → send.
+
+## Files
+- `run.py` — the pipeline (fetch → extract → score → draft → write)
+- `prompts/` — reusable AI prompts (extract, score, draft, follow-up)
+- `sources.example.yml` — optional RSS feeds (copy to `sources.yml`)
+- `company_master_gujarat.csv` — verified pharma employers (seed)
+- `sheet_schema.md` — Sheet tab/column definitions
+- `compliance.md` — what must stay manual and why

--- a/job-outreach/automation/company_master_gujarat.csv
+++ b/job-outreach/automation/company_master_gujarat.csv
@@ -1,0 +1,27 @@
+company,location,distance_from_vadodara_km,career_link,apply_method,target_roles,osd_tablet
+Sun Pharmaceutical Industries,"Halol, Panchmahal",45,https://careers.sunpharma.com/,Official portal (search "Halol"),QA Officer / IPQA / Production QA,Yes
+Alembic Pharmaceuticals,"Vadodara / Panelav (Halol)",10,https://alembicpharmaceuticals.com/careers.aspx,Official portal,QA / IPQA / Documentation QA,Yes
+Bharat Parenterals Ltd,"Haripura, Savli, Vadodara",25,https://in.indeed.com/cmp/Bharat-Parenterals-Ltd,Portal/Indeed (no public HR email),QA / IPQA (Tablet & Injectable),Yes
+Lupin Manufacturing Solutions,"Dabhasa, Vadodara",30,https://www.lupin.com/careers/,Official portal + walk-ins,QC / QA,Yes
+West-Coast Pharmaceutical Works,"Vadodara (Gorwa/Halol)",12,https://in.indeed.com/cmp/West--coast-Pharmaceutical-Works-Ltd,Portal/Indeed,QA / IPQA / Production,Yes
+Torrent Pharmaceuticals,"Indrad (Mehsana) / Dahej",110,https://www.torrentpharma.com/careers/join-us/,Official portal,QA / IPQA Officer,Yes
+Intas Pharmaceuticals,"Matoda / Sanand (Ahmedabad)",100,https://www.intaspharma.com/careers/,Official portal (intasaccordcareers.com),QA / IPQA / Documentation,Yes
+Zydus Lifesciences,"Moraiya / Ahmedabad",100,https://www.zyduslife.com/career,Official portal,QA / IPQA Officer (OSD),Yes
+Cadila Pharmaceuticals,"Dholka (Ahmedabad)",90,https://careers.cadilapharma.com/in/en,Official portal,QA / IPQA / Production QA,Yes
+Ajanta Pharma,"Vadodara / Bharuch (walk-ins)",60,https://www.ajantapharma.com/careers,Official portal + current walk-in,QA / QC / Manufacturing,Yes
+Corona Remedies,"Ahmedabad",95,https://www.coronaremedies.com/career/,Official portal + walk-in,QA / QC / Production,Yes
+Finecure Pharmaceuticals,"Ahmedabad",100,https://www.finecure.in/,Careers section / Indeed,QA / IPQA (Tablet/Capsule),Yes
+Centaur Pharmaceuticals,"Vadodara / Pune",15,https://www.centaurpharma.com/careers/,Official portal,QA / IPQA,Yes
+Maxim Pharmaceuticals,"Vadodara",8,https://www.maximpharma.com/,Careers section (verify on site),QA / IPQA,Yes
+Stallion Laboratories,"Vadodara",10,https://www.stallenlabs.com/,Careers section (verify on site),QA / IPQA / Production,Yes
+
+Amneal Pharmaceuticals India,"Ahmedabad",100,https://india.amneal.com/careers,Official portal (IPQA roles posted),QA / IPQA Officer,Yes
+JB Pharma (J.B. Chemicals),"Panoli, Ankleshwar",70,https://jbpharma.com/careers/,Official portal,QA / IPQA / Production,Yes
+Zentiva,"Ankleshwar",70,https://www.zentiva.com/careers,Official portal / Indeed,QC / QA Officer,Yes
+Lincoln Pharmaceuticals,"Khatraj / Ahmedabad",95,https://www.lincolnpharma.com/career.php,Careers section,QA / IPQA / Production,Yes
+Macleods Pharmaceuticals,"Pan-India (Gujarat units)",110,https://www.macleodspharma.com/careers,Official portal + walk-ins,QA / IPQA / Doc QA,Yes
+Eris Lifesciences,"Ahmedabad / Guwahati",100,https://www.eris.co.in/careers.php,Careers section,QA / IPQA,Yes
+Troikaa Pharmaceuticals,"Ahmedabad / Dehradun",100,https://www.troikaapharma.com/careers,Careers section,QA / IPQA,Yes
+Gufic Biosciences,"Navsari",120,https://gufic.com/careers/,Official portal,QA / IPQA (Injectable),No-Injectable
+Cadila Pharma (API SBU),"Ankleshwar / Dahej",80,https://careers.cadilapharma.com/in/en,Official portal,QA / IPQA (API),No-API
+Sun Pharma (Ankleshwar API),"Ankleshwar",70,https://careers.sunpharma.com/,Official portal,QA (API),No-API

--- a/job-outreach/automation/compliance.md
+++ b/job-outreach/automation/compliance.md
@@ -1,0 +1,23 @@
+# Compliance — what MUST stay manual (and why)
+
+This system is deliberately human-in-the-loop. The following NEVER happen automatically:
+
+1. **Sending** any email, LinkedIn note, message, or application.
+   -> You copy the draft and send it yourself. Prevents spam + keeps you in control.
+
+2. **Logging into LinkedIn** or scraping content behind its login.
+   -> Violates LinkedIn ToS and risks a permanent ban. You open LinkedIn yourself and
+      paste public job / saved-search result URLs into the Inbox tab.
+
+3. **Using unverified contact info.** Emails/phones are stored only if publicly present
+   in the posting; otherwise marked "NOT VERIFIED". You verify before using.
+
+4. **Mass / repeated messaging.** Only two scheduled follow-ups (Day 3, Day 7), and only
+   after you approve.
+
+5. **Secrets** (LLM key, Google key, Sheet ID) live ONLY in GitHub Actions Secrets —
+   never in code, never committed, never in chat. Rotate any key that gets exposed.
+
+What IS automated: fetching pages you queued, extracting fields, scoring, drafting text,
+deduping, and writing a ranked dashboard + daily summary. That's the 95% that saves time;
+the final human click stays with you.

--- a/job-outreach/automation/inbox.txt
+++ b/job-outreach/automation/inbox.txt
@@ -1,0 +1,8 @@
+# PASTE JOB URLs HERE — one per line. Lines starting with # are ignored.
+#
+# How: open LinkedIn / Naukri / Indeed / a company career page, find a QA/IPQA/OSD job,
+# copy its URL, and paste it below (edit this file right here on GitHub — pencil icon).
+# The daily run reads these, scores them, drafts your application, and writes dashboard.md.
+#
+# Example (delete this and add real ones):
+# https://www.naukri.com/job-listings-xxxx

--- a/job-outreach/automation/jobs.csv
+++ b/job-outreach/automation/jobs.csv
@@ -1,0 +1,1 @@
+key,date_added,company,job_title,department,location,walk_in,source_url,official_email,official_phone,eligibility,salary,company_size,match_score,score_reason,subject,email,linkedin_note,linkedin_message,followup_day3,followup_day7,status

--- a/job-outreach/automation/prompts/draft.md
+++ b/job-outreach/automation/prompts/draft.md
@@ -1,0 +1,15 @@
+You are writing application outreach for the CANDIDATE applying to the JOB.
+Tone: professional, concise, specific to the company's manufacturing profile.
+Mention that the resume is attached. If no current opening, request future consideration.
+Do NOT invent facts about the company beyond what the JOB provides.
+
+Return JSON only with these keys:
+{
+  "subject": "Application - QA/IPQA Officer (2 Yrs, OSD/Tablet) | Balaji Rajput",
+  "email": "6-10 line email body, greeting to {company} HR, 2 yrs QA/IPQA in tablet/OSD, key skills (line clearance, in-process compression checks, BMR/BPR, deviation/CAPA, GMP/GDP), resume attached, immediate joiner, request consideration now or future.",
+  "linkedin_note": "<=300 char connection note",
+  "linkedin_message": "short message to send after they connect",
+  "followup_day3": "3-4 line polite follow-up for Day 3",
+  "followup_day7": "3-4 line final polite follow-up for Day 7"
+}
+Keep the email under ~150 words. No emojis. Sign as: Balaji Rajput, +91 8780861044.

--- a/job-outreach/automation/prompts/extract.md
+++ b/job-outreach/automation/prompts/extract.md
@@ -1,0 +1,22 @@
+You are a precise job-posting parser for pharmaceutical roles.
+
+From the PAGE TEXT of a single job posting, extract ONLY facts that are actually present.
+Do NOT guess or invent. If a field is missing, use "" (empty). For email/phone, include
+them ONLY if they clearly appear in the text; otherwise use "NOT VERIFIED".
+
+Return a JSON object with exactly these keys:
+{
+  "company": "",
+  "job_title": "",
+  "department": "",
+  "location": "",
+  "walk_in": "",            // date/time/venue if it is a walk-in, else ""
+  "eligibility": "",        // qualification + years of experience required
+  "salary": "",             // only if explicitly stated
+  "official_email": "",     // only if present in text, else "NOT VERIFIED"
+  "official_phone": "",     // only if present in text, else "NOT VERIFIED"
+  "company_size": "",       // small / mid-size / large / MNC if inferable, else ""
+  "is_pharma_qa_related": true
+}
+Set "is_pharma_qa_related" to false if the posting is clearly not QA/IPQA/Production/
+OSD/tablet/pharma-manufacturing related. Output JSON only.

--- a/job-outreach/automation/prompts/followup.md
+++ b/job-outreach/automation/prompts/followup.md
@@ -1,0 +1,6 @@
+You write short, polite follow-up messages for a job application already sent.
+Never pushy, never repeated more than the two scheduled touches (Day 3, Day 7).
+
+Given CANDIDATE, JOB, and which follow-up ("day3" or "day7"), return JSON only:
+{ "subject": "Following up - {job_title} | Balaji Rajput", "body": "3-4 lines, reference the earlier application, reiterate 2 yrs QA/IPQA OSD fit and immediate availability, thank them." }
+Day-7 should gently indicate it is the final follow-up. No emojis.

--- a/job-outreach/automation/prompts/score.md
+++ b/job-outreach/automation/prompts/score.md
@@ -1,0 +1,16 @@
+You are a job-match scorer for a specific candidate. Compare the JOB to the CANDIDATE
+and return a match score 0-100 with a one-line reason.
+
+Scoring weights:
+- Role relevance (QA/IPQA/Production/tablet-compression/OSD)      40
+- Location relevance (priority Gujarat hubs > other Gujarat > India) 25
+- Experience fit (candidate has 2 yrs; ideal 1-3/2-5/2-7)         20
+- Direct-apply quality / walk-in priority / reputation           15
+
+Rules:
+- If the role is clearly senior (needs 7+ yrs / manager) reduce heavily.
+- If not pharma-QA related, score < 20.
+- Walk-ins in priority locations get a small boost.
+
+Return JSON only:
+{ "match_score": 0-100, "reason": "short reason", "walk_in_priority": true/false }

--- a/job-outreach/automation/requirements.txt
+++ b/job-outreach/automation/requirements.txt
@@ -1,0 +1,6 @@
+requests>=2.31
+feedparser>=6.0
+beautifulsoup4>=4.12
+gspread>=6.0
+google-auth>=2.30
+PyYAML>=6.0

--- a/job-outreach/automation/run.py
+++ b/job-outreach/automation/run.py
@@ -85,6 +85,14 @@ def rss_urls(sources_file):
 
 
 # ----------------------------------------------------------------- sheets
+JOBS_HEADER = [
+    "key", "date_added", "company", "job_title", "department", "location", "walk_in",
+    "source_url", "official_email", "official_phone", "eligibility", "salary",
+    "company_size", "match_score", "score_reason", "subject", "email",
+    "linkedin_note", "linkedin_message", "followup_day3", "followup_day7", "status",
+]
+
+
 def open_sheet():
     import gspread
     from google.oauth2.service_account import Credentials
@@ -93,6 +101,32 @@ def open_sheet():
         info, scopes=["https://www.googleapis.com/auth/spreadsheets"])
     gc = gspread.authorize(creds)
     return gc.open_by_key(os.environ["SHEET_ID"])
+
+
+def ensure_sheet(sh):
+    """Idempotently create the Inbox / Jobs / Summary tabs and headers if missing.
+    So the user only has to create ONE empty Google Sheet + share it."""
+    existing = {w.title: w for w in sh.worksheets()}
+    if "Inbox" not in existing:
+        w = sh.add_worksheet("Inbox", rows=200, cols=1)
+        w.update("A1", [["url"]])
+    else:
+        if (existing["Inbox"].acell("A1").value or "").strip().lower() != "url":
+            existing["Inbox"].update("A1", [["url"]])
+    if "Jobs" not in existing:
+        w = sh.add_worksheet("Jobs", rows=1000, cols=len(JOBS_HEADER))
+        w.update("A1", [JOBS_HEADER])
+    else:
+        if not existing["Jobs"].row_values(1):
+            existing["Jobs"].update("A1", [JOBS_HEADER])
+    if "Summary" not in existing:
+        sh.add_worksheet("Summary", rows=100, cols=8)
+    # remove default "Sheet1" if empty and unused
+    if "Sheet1" in existing and existing["Sheet1"].acell("A1").value in (None, ""):
+        try:
+            sh.del_worksheet(existing["Sheet1"])
+        except Exception:
+            pass
 
 
 def dedup_key(company, title, location, url):
@@ -108,6 +142,7 @@ def main():
             sys.exit(1)
 
     sh = open_sheet()
+    ensure_sheet(sh)   # auto-create Inbox/Jobs/Summary tabs + headers if missing
     inbox = sh.worksheet("Inbox")
     jobs = sh.worksheet("Jobs")
 

--- a/job-outreach/automation/run.py
+++ b/job-outreach/automation/run.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""
+Pharma QA/IPQA job automation - MVP pipeline.
+
+Flow (daily, via GitHub Actions):
+  1. Read job URLs from the Sheet "Inbox" tab (+ optional RSS feeds in sources.yml)
+  2. Fetch each page -> plain text
+  3. LLM: extract structured fields
+  4. Filter (location + experience) and LLM: score 0-100 vs candidate profile
+  5. Dedupe (company+title+location+source_url)
+  6. LLM: draft email + LinkedIn note/message + Day-3/Day-7 follow-ups
+  7. Append new rows to the "Jobs" tab and refresh "Summary"
+
+NEVER sends anything. Secrets come ONLY from environment (GitHub Actions Secrets):
+  OPENROUTER_API_KEY, GOOGLE_SA_JSON, SHEET_ID
+"""
+import os, sys, json, hashlib, datetime, pathlib, re
+import requests
+
+HERE = pathlib.Path(__file__).resolve().parent
+MODEL = os.getenv("LLM_MODEL", "openai/gpt-4o-mini")
+SCORE_THRESHOLD = int(os.getenv("SCORE_THRESHOLD", "55"))
+
+CANDIDATE = """Balaji Rajput - QA/IPQA Officer, 2 years, Solid Oral Dosage (tablet)
+manufacturing. Skills: line clearance, in-process checks (compression: weight
+variation, hardness, friability, thickness, disintegration), BMR/BPR review,
+granulation/compression/coating, deviation, CAPA, IPQA sampling, GMP/GDP,
+documentation. Diploma in Biotechnology (Parul University). Base: Vadodara.
+Priority locations: Vadodara, Ahmedabad, Halol, Savli, Sanand, Changodar, Padra,
+Ankleshwar, Bharuch. Experience fit: 1-3 / 2-5 / 2-7 years."""
+
+
+# ----------------------------------------------------------------- LLM helper
+def llm(system, user, json_out=True):
+    key = os.environ["OPENROUTER_API_KEY"]
+    r = requests.post(
+        "https://openrouter.ai/api/v1/chat/completions",
+        headers={"Authorization": f"Bearer {key}", "Content-Type": "application/json"},
+        json={
+            "model": MODEL,
+            "messages": [{"role": "system", "content": system},
+                         {"role": "user", "content": user}],
+            "temperature": 0.2,
+            **({"response_format": {"type": "json_object"}} if json_out else {}),
+        },
+        timeout=90,
+    )
+    r.raise_for_status()
+    content = r.json()["choices"][0]["message"]["content"]
+    return json.loads(content) if json_out else content
+
+
+def prompt(name):
+    return (HERE / "prompts" / f"{name}.md").read_text(encoding="utf-8")
+
+
+# ----------------------------------------------------------------- fetching
+def fetch_text(url):
+    try:
+        from bs4 import BeautifulSoup
+        html = requests.get(url, timeout=45, headers={"User-Agent": "Mozilla/5.0"}).text
+        soup = BeautifulSoup(html, "html.parser")
+        for t in soup(["script", "style", "noscript"]):
+            t.extract()
+        text = re.sub(r"\n{3,}", "\n\n", soup.get_text("\n"))
+        return text[:12000]
+    except Exception as e:
+        print(f"  ! fetch failed {url}: {e}")
+        return ""
+
+
+def rss_urls(sources_file):
+    urls = []
+    if not sources_file.exists():
+        return urls
+    import yaml, feedparser
+    cfg = yaml.safe_load(sources_file.read_text()) or {}
+    for feed in cfg.get("rss", []):
+        try:
+            for e in feedparser.parse(feed).entries[:25]:
+                urls.append(e.link)
+        except Exception as ex:
+            print(f"  ! rss failed {feed}: {ex}")
+    return urls
+
+
+# ----------------------------------------------------------------- sheets
+def open_sheet():
+    import gspread
+    from google.oauth2.service_account import Credentials
+    info = json.loads(os.environ["GOOGLE_SA_JSON"])
+    creds = Credentials.from_service_account_info(
+        info, scopes=["https://www.googleapis.com/auth/spreadsheets"])
+    gc = gspread.authorize(creds)
+    return gc.open_by_key(os.environ["SHEET_ID"])
+
+
+def dedup_key(company, title, location, url):
+    raw = f"{company}|{title}|{location}|{url}".lower().strip()
+    return hashlib.sha1(raw.encode()).hexdigest()[:12]
+
+
+# ----------------------------------------------------------------- pipeline
+def main():
+    for var in ("OPENROUTER_API_KEY", "GOOGLE_SA_JSON", "SHEET_ID"):
+        if not os.getenv(var):
+            print(f"Missing env {var}. Set it in GitHub Actions Secrets.")
+            sys.exit(1)
+
+    sh = open_sheet()
+    inbox = sh.worksheet("Inbox")
+    jobs = sh.worksheet("Jobs")
+
+    existing_keys = set(r.get("key", "") for r in jobs.get_all_records())
+
+    # collect candidate URLs: Inbox column A (skip header) + optional RSS
+    inbox_urls = [u.strip() for u in inbox.col_values(1)[1:] if u.strip().startswith("http")]
+    urls = list(dict.fromkeys(inbox_urls + rss_urls(HERE / "sources.yml")))
+    print(f"{len(urls)} candidate URLs")
+
+    added = 0
+    for url in urls:
+        text = fetch_text(url)
+        if len(text) < 200:
+            continue
+        try:
+            data = llm(prompt("extract"), f"URL: {url}\n\nPAGE TEXT:\n{text}")
+        except Exception as e:
+            print(f"  ! extract failed {url}: {e}")
+            continue
+
+        company = data.get("company", "").strip() or "NOT VERIFIED"
+        title = data.get("job_title", "").strip()
+        location = data.get("location", "").strip()
+        if not title:
+            continue
+
+        key = dedup_key(company, title, location, url)
+        if key in existing_keys:
+            continue
+
+        try:
+            sc = llm(prompt("score"), f"CANDIDATE:\n{CANDIDATE}\n\nJOB:\n{json.dumps(data)}")
+            score = int(sc.get("match_score", 0))
+        except Exception as e:
+            print(f"  ! score failed: {e}")
+            score = 0
+
+        drafts = {}
+        if score >= SCORE_THRESHOLD:
+            try:
+                drafts = llm(prompt("draft"),
+                             f"CANDIDATE:\n{CANDIDATE}\n\nJOB:\n{json.dumps(data)}")
+            except Exception as e:
+                print(f"  ! draft failed: {e}")
+
+        row = [
+            key,
+            datetime.date.today().isoformat(),
+            company, title, data.get("department", ""),
+            location, data.get("walk_in", ""),
+            url, data.get("official_email", "NOT VERIFIED"),
+            data.get("official_phone", "NOT VERIFIED"),
+            data.get("eligibility", ""), data.get("salary", ""),
+            data.get("company_size", ""), score,
+            sc.get("reason", "") if score else "",
+            drafts.get("subject", ""), drafts.get("email", ""),
+            drafts.get("linkedin_note", ""), drafts.get("linkedin_message", ""),
+            drafts.get("followup_day3", ""), drafts.get("followup_day7", ""),
+            "new",
+        ]
+        jobs.append_row(row, value_input_option="RAW")
+        existing_keys.add(key)
+        added += 1
+        print(f"  + [{score}] {company} - {title} ({location})")
+
+    write_summary(sh, added)
+    print(f"Done. {added} new jobs added.")
+
+
+def write_summary(sh, added):
+    try:
+        summary = sh.worksheet("Summary")
+    except Exception:
+        return
+    recs = sh.worksheet("Jobs").get_all_records()
+    ranked = sorted(recs, key=lambda r: int(r.get("match_score", 0) or 0), reverse=True)
+    top = ranked[:10]
+    walkins = [r for r in recs if str(r.get("walk_in", "")).strip()][:10]
+    today = datetime.date.today().isoformat()
+    lines = [[f"Daily summary - {today}"], [f"New added today: {added}"], [""],
+             ["TOP 10 MATCHES"], ["Score", "Company", "Title", "Location", "Link"]]
+    for r in top:
+        lines.append([r.get("match_score"), r.get("company"), r.get("job_title"),
+                      r.get("location"), r.get("source_url")])
+    lines += [[""], ["BEST WALK-INS"], ["Company", "Walk-in", "Location"]]
+    for r in walkins:
+        lines.append([r.get("company"), r.get("walk_in"), r.get("location")])
+    summary.clear()
+    summary.update("A1", lines)
+
+
+if __name__ == "__main__":
+    main()

--- a/job-outreach/automation/run_repo.py
+++ b/job-outreach/automation/run_repo.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""
+Repo-native pipeline (NO Google account needed).
+
+Reads job URLs from inbox.txt -> fetch -> LLM extract -> filter -> LLM score ->
+dedupe (against jobs.csv) -> LLM draft -> append to jobs.csv -> regenerate dashboard.md.
+
+The GitHub Actions workflow commits jobs.csv + dashboard.md back to the repo.
+NEVER sends anything. Only secret required: OPENROUTER_API_KEY.
+"""
+import os, sys, json, csv, hashlib, datetime, pathlib, re
+import requests
+
+HERE = pathlib.Path(__file__).resolve().parent
+INBOX = HERE / "inbox.txt"
+JOBS_CSV = HERE / "jobs.csv"
+DASHBOARD = HERE / "dashboard.md"
+MODEL = os.getenv("LLM_MODEL", "openai/gpt-4o-mini")
+SCORE_THRESHOLD = int(os.getenv("SCORE_THRESHOLD", "55"))
+
+FIELDS = ["key", "date_added", "company", "job_title", "department", "location",
+          "walk_in", "source_url", "official_email", "official_phone", "eligibility",
+          "salary", "company_size", "match_score", "score_reason", "subject", "email",
+          "linkedin_note", "linkedin_message", "followup_day3", "followup_day7", "status"]
+
+CANDIDATE = """Balaji Rajput - QA/IPQA Officer, 2 years, Solid Oral Dosage (tablet)
+manufacturing. Skills: line clearance, in-process checks (compression: weight variation,
+hardness, friability, thickness, disintegration), BMR/BPR review, granulation/compression/
+coating, deviation, CAPA, IPQA sampling, GMP/GDP, documentation. Diploma in Biotechnology
+(Parul University). Base: Vadodara. Priority: Vadodara, Ahmedabad, Halol, Savli, Sanand,
+Changodar, Padra, Ankleshwar, Bharuch. Experience fit: 1-3 / 2-5 / 2-7 years."""
+
+
+def llm(system, user, json_out=True):
+    key = os.environ["OPENROUTER_API_KEY"]
+    r = requests.post(
+        "https://openrouter.ai/api/v1/chat/completions",
+        headers={"Authorization": f"Bearer {key}", "Content-Type": "application/json"},
+        json={"model": MODEL,
+              "messages": [{"role": "system", "content": system},
+                           {"role": "user", "content": user}],
+              "temperature": 0.2,
+              **({"response_format": {"type": "json_object"}} if json_out else {})},
+        timeout=90)
+    r.raise_for_status()
+    c = r.json()["choices"][0]["message"]["content"]
+    return json.loads(c) if json_out else c
+
+
+def prompt(name):
+    return (HERE / "prompts" / f"{name}.md").read_text(encoding="utf-8")
+
+
+def fetch_text(url):
+    try:
+        from bs4 import BeautifulSoup
+        html = requests.get(url, timeout=45, headers={"User-Agent": "Mozilla/5.0"}).text
+        soup = BeautifulSoup(html, "html.parser")
+        for t in soup(["script", "style", "noscript"]):
+            t.extract()
+        return re.sub(r"\n{3,}", "\n\n", soup.get_text("\n"))[:12000]
+    except Exception as e:
+        print(f"  ! fetch failed {url}: {e}")
+        return ""
+
+
+def read_inbox():
+    if not INBOX.exists():
+        return []
+    out = []
+    for line in INBOX.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line.startswith("http"):
+            out.append(line)
+    return list(dict.fromkeys(out))
+
+
+def read_jobs():
+    if not JOBS_CSV.exists():
+        return []
+    with open(JOBS_CSV, newline="", encoding="utf-8") as f:
+        return list(csv.DictReader(f))
+
+
+def write_jobs(rows):
+    with open(JOBS_CSV, "w", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(f, fieldnames=FIELDS)
+        w.writeheader()
+        for r in rows:
+            w.writerow({k: r.get(k, "") for k in FIELDS})
+
+
+def dkey(company, title, location, url):
+    return hashlib.sha1(f"{company}|{title}|{location}|{url}".lower().encode()).hexdigest()[:12]
+
+
+def main():
+    if not os.getenv("OPENROUTER_API_KEY"):
+        print("Missing OPENROUTER_API_KEY (add it in repo Settings -> Secrets -> Actions).")
+        sys.exit(1)
+
+    rows = read_jobs()
+    keys = {r["key"] for r in rows}
+    urls = read_inbox()
+    print(f"{len(urls)} inbox URLs, {len(rows)} existing jobs")
+
+    added = 0
+    for url in urls:
+        text = fetch_text(url)
+        if len(text) < 200:
+            continue
+        try:
+            d = llm(prompt("extract"), f"URL: {url}\n\nPAGE TEXT:\n{text}")
+        except Exception as e:
+            print(f"  ! extract failed: {e}"); continue
+        if d.get("is_pharma_qa_related") is False:
+            continue
+        company = (d.get("company") or "NOT VERIFIED").strip()
+        title = (d.get("job_title") or "").strip()
+        location = (d.get("location") or "").strip()
+        if not title:
+            continue
+        k = dkey(company, title, location, url)
+        if k in keys:
+            continue
+        try:
+            sc = llm(prompt("score"), f"CANDIDATE:\n{CANDIDATE}\n\nJOB:\n{json.dumps(d)}")
+            score = int(sc.get("match_score", 0))
+        except Exception as e:
+            print(f"  ! score failed: {e}"); score = 0; sc = {}
+        drafts = {}
+        if score >= SCORE_THRESHOLD:
+            try:
+                drafts = llm(prompt("draft"), f"CANDIDATE:\n{CANDIDATE}\n\nJOB:\n{json.dumps(d)}")
+            except Exception as e:
+                print(f"  ! draft failed: {e}")
+        rows.append({
+            "key": k, "date_added": datetime.date.today().isoformat(),
+            "company": company, "job_title": title, "department": d.get("department", ""),
+            "location": location, "walk_in": d.get("walk_in", ""), "source_url": url,
+            "official_email": d.get("official_email", "NOT VERIFIED"),
+            "official_phone": d.get("official_phone", "NOT VERIFIED"),
+            "eligibility": d.get("eligibility", ""), "salary": d.get("salary", ""),
+            "company_size": d.get("company_size", ""), "match_score": score,
+            "score_reason": sc.get("reason", ""), "subject": drafts.get("subject", ""),
+            "email": drafts.get("email", ""), "linkedin_note": drafts.get("linkedin_note", ""),
+            "linkedin_message": drafts.get("linkedin_message", ""),
+            "followup_day3": drafts.get("followup_day3", ""),
+            "followup_day7": drafts.get("followup_day7", ""), "status": "new"})
+        keys.add(k); added += 1
+        print(f"  + [{score}] {company} - {title} ({location})")
+
+    rows.sort(key=lambda r: int(r.get("match_score") or 0), reverse=True)
+    write_jobs(rows)
+    write_dashboard(rows, added)
+    print(f"Done. {added} new. Total {len(rows)}.")
+
+
+def write_dashboard(rows, added):
+    today = datetime.date.today().isoformat()
+    top = rows[:10]
+    walkins = [r for r in rows if str(r.get("walk_in", "")).strip()]
+    md = [f"# Job Dashboard — updated {today}", "",
+          f"- New added today: **{added}**  |  Total tracked: **{len(rows)}**",
+          f"- Walk-ins available: **{len(walkins)}**", "",
+          "## Top 10 Matches", "",
+          "| Score | Company | Title | Location | Link |",
+          "|------:|---------|-------|----------|------|"]
+    for r in top:
+        md.append(f"| {r.get('match_score')} | {r.get('company')} | {r.get('job_title')} "
+                  f"| {r.get('location')} | [open]({r.get('source_url')}) |")
+    if walkins:
+        md += ["", "## Walk-ins", "", "| Company | Walk-in | Location |",
+               "|---------|---------|----------|"]
+        for r in walkins[:10]:
+            md.append(f"| {r.get('company')} | {r.get('walk_in')} | {r.get('location')} |")
+    md += ["", "## Ready-to-send drafts (top matches)", ""]
+    for r in top:
+        if not r.get("email"):
+            continue
+        md += [f"<details><summary><b>{r.get('company')} — {r.get('job_title')} "
+               f"(score {r.get('match_score')})</b></summary>", "",
+               f"**Apply:** {r.get('source_url')}  ",
+               f"**Email (verified?):** {r.get('official_email')}  ",
+               f"**Subject:** {r.get('subject')}", "", "```", r.get("email", ""), "```",
+               "**LinkedIn note:** " + r.get("linkedin_note", ""), "",
+               "**Follow-up (Day 3):** " + r.get("followup_day3", ""), "",
+               "</details>", ""]
+    md += ["", "> Review, set status in jobs.csv, then SEND yourself. Nothing is auto-sent."]
+    DASHBOARD.write_text("\n".join(md), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/job-outreach/automation/sheet_schema.md
+++ b/job-outreach/automation/sheet_schema.md
@@ -1,0 +1,23 @@
+# Google Sheet schema
+
+Create ONE Google Sheet with 3 tabs.
+
+## Tab: Inbox   (you paste URLs here)
+| A: url |
+|--------|
+| (row 1 = header "url") |
+| https://... a job / career-page / LinkedIn saved-search result URL you opened |
+
+## Tab: Jobs   (the system writes here — this is your dashboard)
+Header row (row 1), in this exact order:
+key | date_added | company | job_title | department | location | walk_in |
+source_url | official_email | official_phone | eligibility | salary |
+company_size | match_score | score_reason | subject | email |
+linkedin_note | linkedin_message | followup_day3 | followup_day7 | status
+
+- `status` values: new, shortlisted, drafted, approved, applied, follow-up due,
+  replied, interview scheduled, rejected, closed.
+- Sort/filter by `match_score` (descending) to see best matches.
+
+## Tab: Summary   (auto-refreshed daily)
+Top 10 matches + best walk-ins + counts. Read-only; regenerated each run.

--- a/job-outreach/automation/sources.example.yml
+++ b/job-outreach/automation/sources.example.yml
@@ -1,0 +1,7 @@
+# Copy to sources.yml. OPTIONAL RSS feeds (public, compliant).
+# The primary source is the "Inbox" tab of your Google Sheet where you paste job URLs
+# (including LinkedIn saved-search result URLs you open yourself).
+#
+# Add only public RSS feeds you trust. Leave empty if you only use the Inbox tab.
+rss: []
+  # - https://www.example-jobboard.com/feed/qa-pharma-gujarat.rss


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @balajirajput96 :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro Web](https://kiro.dev/web/)</sub>

---
Compliant, no-server, mostly-automated pharma QA/IPQA job system. Runs daily on GitHub Actions, uses an LLM to extract/score/draft, writes a ranked dashboard to a Google Sheet. **Never sends anything** - user approves + sends.

## Contents (`job-outreach/automation/`)
- `run.py` - pipeline: fetch (from Sheet Inbox tab + optional RSS) -> LLM extract -> filter -> LLM score -> dedupe -> LLM draft (email + LinkedIn + Day-3/Day-7 follow-ups) -> write to Sheet + daily summary.
- `prompts/` - reusable AI prompts (extract, score, draft, follow-up).
- `sheet_schema.md` - Google Sheet tabs/columns (Inbox / Jobs / Summary).
- `company_master_gujarat.csv` - seed of verified Gujarat pharma employers.
- `compliance.md` - exactly what stays manual and why.
- `requirements.txt`, `sources.example.yml`, `.env.example`.
- `.github/workflows/daily-jobs.yml` - daily cron (09:00 IST) + manual run button.

## Security
- Secrets (`OPENROUTER_API_KEY`, `GOOGLE_SA_JSON`, `SHEET_ID`) come ONLY from GitHub Actions Secrets. Nothing hardcoded, nothing committed.
- Any API key exposed in chat/DM must be revoked and recreated before use.

## Setup
See `job-outreach/automation/README.md` (create Sheet + Google service account + new LLM key + add 3 GitHub Secrets + enable workflow). `run.py` passes `python -m py_compile`. It needs the user's Sheet + secrets to run end-to-end (cannot be tested without them).