### PR TITLE
Fix job-automation: workflow push, multi-job extract, seed inbox

### DIFF
--- a/.github/workflows/daily-jobs.yml
+++ b/.github/workflows/daily-jobs.yml
@@ -37,4 +37,4 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add jobs.csv dashboard.md
           git diff --staged --quiet || git commit -m "chore: daily job scan update"
-          git push
+          git push origin HEAD:main

--- a/job-outreach/automation/inbox.txt
+++ b/job-outreach/automation/inbox.txt
@@ -1,8 +1,14 @@
 # PASTE JOB URLs HERE — one per line. Lines starting with # are ignored.
+# The daily run reads these, extracts jobs, scores them for your QA/IPQA OSD profile,
+# drafts your application, and writes dashboard.md.
 #
-# How: open LinkedIn / Naukri / Indeed / a company career page, find a QA/IPQA/OSD job,
-# copy its URL, and paste it below (edit this file right here on GitHub — pencil icon).
-# The daily run reads these, scores them, drafts your application, and writes dashboard.md.
+# TIP: server-rendered pages (like pharmatutor, many company career pages) extract best.
+# JS-heavy sites (LinkedIn/Naukri/Indeed) may show little text to a simple fetch — for
+# those, open the specific job and paste its direct posting URL, or use the pages below.
 #
-# Example (delete this and add real ones):
-# https://www.naukri.com/job-listings-xxxx
+# --- Starter set (QA/IPQA/OSD, Gujarat + India) — edit/add freely ---
+https://www.pharmatutor.org/pharma-jobs
+https://india.amneal.com/careers/search-our-career-opportunities
+https://alembicpharmaceuticals.com/careers.aspx
+https://careers.cadilapharma.com/in/en
+https://www.torrentpharma.com/careers/join-us/

--- a/job-outreach/automation/prompts/extract.md
+++ b/job-outreach/automation/prompts/extract.md
@@ -1,22 +1,31 @@
-You are a precise job-posting parser for pharmaceutical roles.
+You are a precise parser for pharmaceutical job pages.
 
-From the PAGE TEXT of a single job posting, extract ONLY facts that are actually present.
-Do NOT guess or invent. If a field is missing, use "" (empty). For email/phone, include
-them ONLY if they clearly appear in the text; otherwise use "NOT VERIFIED".
+A page may contain ONE job posting OR a LIST of many jobs (search results / careers page).
+Extract EVERY distinct QA / IPQA / Quality Assurance / Production Officer / tablet-
+compression / OSD / pharma-manufacturing job you can clearly identify.
 
-Return a JSON object with exactly these keys:
+Rules:
+- Use ONLY facts present in the text. Do NOT guess or invent.
+- For email/phone: include ONLY if clearly shown in the text; else "NOT VERIFIED".
+- If a field is missing, use "".
+- Ignore non-pharma-QA roles (sales, marketing, IT, etc.).
+- If nothing relevant is found, return {"jobs": []}.
+
+Return a JSON object exactly like:
 {
-  "company": "",
-  "job_title": "",
-  "department": "",
-  "location": "",
-  "walk_in": "",            // date/time/venue if it is a walk-in, else ""
-  "eligibility": "",        // qualification + years of experience required
-  "salary": "",             // only if explicitly stated
-  "official_email": "",     // only if present in text, else "NOT VERIFIED"
-  "official_phone": "",     // only if present in text, else "NOT VERIFIED"
-  "company_size": "",       // small / mid-size / large / MNC if inferable, else ""
-  "is_pharma_qa_related": true
+  "jobs": [
+    {
+      "company": "",
+      "job_title": "",
+      "department": "",
+      "location": "",
+      "walk_in": "",          // date/time/venue if walk-in, else ""
+      "eligibility": "",      // qualification + years required
+      "salary": "",           // only if explicitly stated
+      "official_email": "",   // only if present, else "NOT VERIFIED"
+      "official_phone": "",   // only if present, else "NOT VERIFIED"
+      "company_size": ""      // small / mid-size / large / MNC if inferable, else ""
+    }
+  ]
 }
-Set "is_pharma_qa_related" to false if the posting is clearly not QA/IPQA/Production/
-OSD/tablet/pharma-manufacturing related. Output JSON only.
+Output JSON only.

--- a/job-outreach/automation/run_repo.py
+++ b/job-outreach/automation/run_repo.py
@@ -108,47 +108,54 @@ def main():
     for url in urls:
         text = fetch_text(url)
         if len(text) < 200:
+            print(f"  - skipped (little/no text, maybe JS-only page): {url}")
             continue
         try:
-            d = llm(prompt("extract"), f"URL: {url}\n\nPAGE TEXT:\n{text}")
+            data = llm(prompt("extract"), f"URL: {url}\n\nPAGE TEXT:\n{text}")
         except Exception as e:
             print(f"  ! extract failed: {e}"); continue
-        if d.get("is_pharma_qa_related") is False:
+
+        job_list = data.get("jobs", []) if isinstance(data, dict) else []
+        if not job_list:
+            print(f"  - no relevant jobs found on: {url}")
             continue
-        company = (d.get("company") or "NOT VERIFIED").strip()
-        title = (d.get("job_title") or "").strip()
-        location = (d.get("location") or "").strip()
-        if not title:
-            continue
-        k = dkey(company, title, location, url)
-        if k in keys:
-            continue
-        try:
-            sc = llm(prompt("score"), f"CANDIDATE:\n{CANDIDATE}\n\nJOB:\n{json.dumps(d)}")
-            score = int(sc.get("match_score", 0))
-        except Exception as e:
-            print(f"  ! score failed: {e}"); score = 0; sc = {}
-        drafts = {}
-        if score >= SCORE_THRESHOLD:
+
+        for d in job_list:
+            company = (d.get("company") or "NOT VERIFIED").strip()
+            title = (d.get("job_title") or "").strip()
+            location = (d.get("location") or "").strip()
+            if not title:
+                continue
+            k = dkey(company, title, location, url)
+            if k in keys:
+                continue
             try:
-                drafts = llm(prompt("draft"), f"CANDIDATE:\n{CANDIDATE}\n\nJOB:\n{json.dumps(d)}")
+                sc = llm(prompt("score"), f"CANDIDATE:\n{CANDIDATE}\n\nJOB:\n{json.dumps(d)}")
+                score = int(sc.get("match_score", 0))
             except Exception as e:
-                print(f"  ! draft failed: {e}")
-        rows.append({
-            "key": k, "date_added": datetime.date.today().isoformat(),
-            "company": company, "job_title": title, "department": d.get("department", ""),
-            "location": location, "walk_in": d.get("walk_in", ""), "source_url": url,
-            "official_email": d.get("official_email", "NOT VERIFIED"),
-            "official_phone": d.get("official_phone", "NOT VERIFIED"),
-            "eligibility": d.get("eligibility", ""), "salary": d.get("salary", ""),
-            "company_size": d.get("company_size", ""), "match_score": score,
-            "score_reason": sc.get("reason", ""), "subject": drafts.get("subject", ""),
-            "email": drafts.get("email", ""), "linkedin_note": drafts.get("linkedin_note", ""),
-            "linkedin_message": drafts.get("linkedin_message", ""),
-            "followup_day3": drafts.get("followup_day3", ""),
-            "followup_day7": drafts.get("followup_day7", ""), "status": "new"})
-        keys.add(k); added += 1
-        print(f"  + [{score}] {company} - {title} ({location})")
+                print(f"  ! score failed: {e}"); score = 0; sc = {}
+            drafts = {}
+            if score >= SCORE_THRESHOLD:
+                try:
+                    drafts = llm(prompt("draft"),
+                                 f"CANDIDATE:\n{CANDIDATE}\n\nJOB:\n{json.dumps(d)}")
+                except Exception as e:
+                    print(f"  ! draft failed: {e}")
+            rows.append({
+                "key": k, "date_added": datetime.date.today().isoformat(),
+                "company": company, "job_title": title, "department": d.get("department", ""),
+                "location": location, "walk_in": d.get("walk_in", ""), "source_url": url,
+                "official_email": d.get("official_email", "NOT VERIFIED"),
+                "official_phone": d.get("official_phone", "NOT VERIFIED"),
+                "eligibility": d.get("eligibility", ""), "salary": d.get("salary", ""),
+                "company_size": d.get("company_size", ""), "match_score": score,
+                "score_reason": sc.get("reason", ""), "subject": drafts.get("subject", ""),
+                "email": drafts.get("email", ""), "linkedin_note": drafts.get("linkedin_note", ""),
+                "linkedin_message": drafts.get("linkedin_message", ""),
+                "followup_day3": drafts.get("followup_day3", ""),
+                "followup_day7": drafts.get("followup_day7", ""), "status": "new"})
+            keys.add(k); added += 1
+            print(f"  + [{score}] {company} - {title} ({location})")
 
     rows.sort(key=lambda r: int(r.get("match_score") or 0), reverse=True)
     write_jobs(rows)


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @balajirajput96 :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro Web](https://kiro.dev/web/)</sub>

---
Fixes on top of the merged automation MVP so the daily run works end-to-end.

## Fixes
1. **Workflow push bug** - git push from a detached HEAD (schedule/dispatch checkout) would fail; changed to `git push origin HEAD:main` so daily results commit correctly.
2. **Multi-job extraction** - prompts/extract.md now returns {"jobs": [...]} and run_repo.py iterates, so a single URL that is a search/careers listing yields multiple jobs. Clearer skip logs for JS-only pages.
3. **Seed inbox.txt** with real, mostly server-rendered starter URLs (pharmatutor, Amneal, Alembic, Cadila, Torrent).

run_repo.py passes py_compile. After merge, the daily workflow (or manual Run workflow) populates jobs.csv + dashboard.md.

Note: LinkedIn/Naukri/Indeed are JS-heavy; prefer direct posting URLs or server-rendered career pages for best extraction.