### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Information Exposure in API Error Response

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-07-08 - Prevent Information Leakage in API Error Responses
+**Vulnerability:** Fastapi's `HTTPException` was returning the raw exception string `str(e)` on a 500 error, exposing potentially sensitive internal server details or stack traces to the end user.
+**Learning:** This is a common pattern when developers quickly add a try-catch block but forget that error details returned to the client can leak sensitive architecture information, path structures, or database details.
+**Prevention:** Always log the verbose error details internally (e.g., using `logger.error`), but return a generic, non-descriptive error message (e.g., "An internal error occurred") in the HTTP response.

--- a/main.py
+++ b/main.py
@@ -2,6 +2,9 @@ from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 import numpy as np
 from typing import List
+from utils.logger import setup_logger
+
+logger = setup_logger(__name__)
 
 app = FastAPI(title="ML Model API")
 
@@ -24,4 +27,5 @@ def predict(data: PredictionInput):
         prediction = np.random.random() * 100
         return {"prediction": float(prediction)}
     except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+        logger.error(f"Prediction failed: {e}")
+        raise HTTPException(status_code=500, detail="An internal error occurred")


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The FastAPI `/predict` endpoint was returning raw exception strings (`str(e)`) in its `HTTPException` detail field upon a 500 error. This could expose potentially sensitive internal server details, stack traces, or architectural information to the end user.
🎯 **Impact:** Information leakage that could aid an attacker in understanding the system's internal workings, file paths, or dependencies.
🔧 **Fix:** Replaced the detailed client-facing error message with a generic "An internal error occurred" string. Added internal logging using the existing `utils.logger` to ensure errors are still captured for debugging purposes without being exposed externally. Created a `.jules/sentinel.md` journal entry.
✅ **Verification:** 
- Run `uvicorn main:app --host 0.0.0.0 --port 8000 &`
- Run `python test.py` to ensure normal operation still works. 
- You can force an error in the endpoint (e.g., by sending invalid data or causing a mock model failure) and verify the 500 response only returns `{"detail":"An internal error occurred"}`.

---
*PR created automatically by Jules for task [2396932418798571638](https://jules.google.com/task/2396932418798571638) started by @balajirajput96*