### PR TITLE
🎨 Palette: Link FAQ button with answer content using `aria-controls`

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-18 - [UX] Sidebar Active State and Nav Landmark
 **Learning:** Adding the selected state to the Material-UI List item provides instant visibility of system status, and defining the List as a `nav` component greatly increases accessibility for screen readers.
 **Action:** Always verify if a primary sidebar list acts as main navigation, and provide `useLocation` to determine the active route.
+
+## 2023-10-27 - ARIA Controls on Framer Motion Components
+**Learning:** Expanding/collapsible regions managed by Framer Motion's `<AnimatePresence>` and `<motion.div>` don't natively map their relationships to toggle buttons for screen readers. In this codebase's FAQ section, toggles were missing `aria-controls` explicitly linking the toggle button to the target content container.
+**Action:** Always add explicit `id` to the `<motion.div>` target and matching `aria-controls={id}` to the corresponding toggle `<button>` when building or maintaining animated collapsible regions, especially since animation libraries don't enforce these semantic links.

--- a/src/components/landing/FAQ.tsx
+++ b/src/components/landing/FAQ.tsx
@@ -64,6 +64,7 @@ export function FAQ() {
                     fontSize: '1.125rem'
                   }}
                   aria-expanded={isOpen}
+                  aria-controls={`faq-answer-${index}`}
                 >
                   {faq.q}
                   <motion.div
@@ -79,6 +80,7 @@ export function FAQ() {
                 <AnimatePresence>
                   {isOpen && (
                     <motion.div
+                      id={`faq-answer-${index}`}
                       initial={{ height: 0, opacity: 0 }}
                       animate={{ height: 'auto', opacity: 1 }}
                       exit={{ height: 0, opacity: 0 }}


### PR DESCRIPTION
Added ARIA linkage for screen readers on the FAQ section toggle buttons and content.

---
*PR created automatically by Jules for task [12984675243093907255](https://jules.google.com/task/12984675243093907255) started by @balajirajput96*