### PR TITLE
🎨 Palette: Improve Install Command Copy Button UX & Accessibility

### DIFF
--- a/src/components/landing/InstallCommand.tsx
+++ b/src/components/landing/InstallCommand.tsx
@@ -58,6 +58,7 @@ export function InstallCommand() {
         whileTap={{ scale: 0.95 }}
         onClick={handleCopy}
         aria-label="Copy install command"
+        title={copied ? "Copied!" : "Copy to clipboard"}
         style={{
           background: 'var(--bg-color)',
           border: '1px solid var(--border-color)',
@@ -101,6 +102,11 @@ export function InstallCommand() {
           )}
         </AnimatePresence>
       </motion.button>
+
+      {/* Screen reader only announcement */}
+      <span aria-live="polite" style={{ position: 'absolute', width: '1px', height: '1px', padding: 0, margin: '-1px', overflow: 'hidden', clip: 'rect(0, 0, 0, 0)', whiteSpace: 'nowrap', borderWidth: 0 }}>
+        {copied ? "Copied to clipboard" : ""}
+      </span>
     </motion.div>
   );
 }


### PR DESCRIPTION
### 💡 What
Added a native `title` tooltip ("Copy to clipboard" / "Copied!") and a visually hidden `aria-live="polite"` span to the install command copy button.

### 🎯 Why
- Sighted users receive native OS/browser tooltip hints when hovering over the icon-only copy button, and visual confirmation when the copy succeeds.
- Screen reader users receive an audible announcement ("Copied to clipboard") when they successfully invoke the copy action, which was previously missing.

### 📸 Before/After
*(Visuals verified via Playwright screenshot/video recording in verification step)*
**Before**: Button had `aria-label` but lacked a native tooltip and `aria-live` announcement.
**After**: Button correctly displays tooltip on hover and announces text for screen readers upon interaction.

### ♿ Accessibility
- Added `title` attribute for native mouse/hover tooltips.
- Added visually hidden `aria-live="polite"` region for dynamic screen reader announcements of successful copy actions.

---
*PR created automatically by Jules for task [8940866306374528442](https://jules.google.com/task/8940866306374528442) started by @balajirajput96*