### PR TITLE
⚡ Bolt: Replace React-state blinking cursor with CSS animation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -7,3 +7,11 @@
 ## 2024-05-14 - Extracted Static JSX in Frequently Rendered Component
 **Learning:** In components with frequent state-driven re-renders (like typing animations using `setInterval`), inline static JSX elements are re-created and diffed by React on every frame.
 **Action:** Extract large, purely static JSX blocks to constants completely outside the component function. This ensures the React element is created only once, and the reconciler can skip diffing it entirely since the element reference remains stable (`oldElement === newElement`).
+
+## 2025-02-14 - Replace requests with Session for connection pooling
+**Learning:** Using bare `requests.get()` and `requests.post()` repeatedly within a script opens a new TCP connection (and full TLS handshake) for every API request, which adds a lot of latency.
+**Action:** Use a shared `requests.Session()` which uses connection pooling natively to improve API latency, especially when communicating with the same host multiple times (like an LLM inference API).
+
+## 2025-02-14 - Move state-driven animations to CSS
+**Learning:** Using React state and `setInterval`/`useEffect` to drive visual animations like cursor blinking (e.g., in `TerminalPreview.tsx`) causes unnecessary and continuous component re-renders (in this case, 2 re-renders per second, indefinitely).
+**Action:** Always prefer CSS `@keyframes` animations for simple, continuous visual effects to offload the work from the main thread and prevent excessive React re-renders.


### PR DESCRIPTION
💡 **What:** 
Replaced a React state-driven cursor blink animation with a native CSS `@keyframes` animation in `TerminalPreview.tsx`. Moved the static `lines` data out of the component function to prevent recreating it on every render.

🎯 **Why:**
Using `setInterval` to toggle state (`setShowCursor`) every 500ms caused the `TerminalPreview` component to continually re-render twice a second forever, even when not typing. This wasted CPU cycles and caused unnecessary allocations. 

📊 **Impact:** 
Reduces component re-renders while idle from 2/sec to 0/sec. Main thread overhead is effectively eliminated since the blinking is now fully handled by the browser's CSS compositor.

🔬 **Measurement:**
Check the React DevTools Profiler while staring at the blinking cursor, observing that no component updates fire for the blinking alone. Alternatively, visually verify that the terminal cursor continues to blink normally.

---
*PR created automatically by Jules for task [4452661617396944441](https://jules.google.com/task/4452661617396944441) started by @balajirajput96*