### PR TITLE
🎨 Palette: Add copy button to Quickstart code snippets

### DIFF
--- a/src/components/landing/Quickstart.tsx
+++ b/src/components/landing/Quickstart.tsx
@@ -1,5 +1,97 @@
-import { motion } from 'framer-motion';
+import { useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
 import { SectionHeading } from './SectionHeading';
+
+function CodeSnippet({ code }: { code: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error('Failed to copy text: ', err);
+    }
+  };
+
+  return (
+    <div style={{
+      background: 'var(--bg-color)',
+      border: '1px solid var(--border-color)',
+      borderRadius: '8px',
+      padding: '1rem',
+      fontFamily: 'var(--font-code)',
+      fontSize: '0.875rem',
+      color: 'var(--secondary-accent)',
+      position: 'relative',
+      display: 'flex',
+      alignItems: 'flex-start',
+      justifyContent: 'space-between',
+      gap: '1rem',
+    }}>
+      <div style={{ overflowX: 'auto', whiteSpace: 'pre', paddingRight: '2rem' }}>
+        {code}
+      </div>
+
+      <motion.button
+        whileHover={{ scale: 1.05, backgroundColor: 'var(--surface-hover)' }}
+        whileTap={{ scale: 0.95 }}
+        onClick={handleCopy}
+        aria-label="Copy code snippet"
+        title={copied ? "Copied!" : "Copy to clipboard"}
+        style={{
+          background: 'transparent',
+          border: 'none',
+          padding: '0.25rem',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          cursor: 'pointer',
+          color: 'var(--muted-color)',
+          transition: 'color 0.2s',
+          minWidth: '32px',
+          height: '32px',
+          borderRadius: '6px',
+          flexShrink: 0
+        }}
+      >
+        <AnimatePresence mode="wait">
+          {copied ? (
+            <motion.div
+              key="check"
+              initial={{ opacity: 0, scale: 0.5 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0, scale: 0.5 }}
+              style={{ color: 'var(--primary-accent)' }}
+            >
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <polyline points="20 6 9 17 4 12"></polyline>
+              </svg>
+            </motion.div>
+          ) : (
+            <motion.div
+              key="copy"
+              initial={{ opacity: 0, scale: 0.5 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0, scale: 0.5 }}
+            >
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+              </svg>
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </motion.button>
+
+      {/* Screen reader only announcement */}
+      <span aria-live="polite" style={{ position: 'absolute', width: '1px', height: '1px', padding: 0, margin: '-1px', overflow: 'hidden', clip: 'rect(0, 0, 0, 0)', whiteSpace: 'nowrap', borderWidth: 0 }}>
+        {copied ? "Copied code to clipboard" : ""}
+      </span>
+    </div>
+  );
+}
 
 export function Quickstart() {
   const steps = [
@@ -82,19 +174,7 @@ export function Quickstart() {
                 <h3 style={{ fontSize: '1.5rem', marginBottom: '0.5rem' }}>{step.title}</h3>
                 <p style={{ color: 'var(--muted-color)', marginBottom: '1.5rem' }}>{step.description}</p>
 
-                <div style={{
-                  background: 'var(--bg-color)',
-                  border: '1px solid var(--border-color)',
-                  borderRadius: '8px',
-                  padding: '1rem',
-                  fontFamily: 'var(--font-code)',
-                  fontSize: '0.875rem',
-                  color: 'var(--secondary-accent)',
-                  overflowX: 'auto',
-                  whiteSpace: 'pre'
-                }}>
-                  {step.code}
-                </div>
+                <CodeSnippet code={step.code} />
               </div>
             </motion.div>
           ))}


### PR DESCRIPTION
💡 **What**: Added a one-click copy button to the code snippets in the Quickstart section. 

🎯 **Why**: Previously, users had to manually highlight and copy the command snippets, which is poor UX for a technical developer tool's documentation/landing page. This addition aligns the Quickstart experience with the existing Hero install command experience.

📸 **Before/After**: The new `CodeSnippet` UI matches the existing dark retro-futuristic theme perfectly, using appropriate CSS variables.

♿ **Accessibility**:
- Added `aria-label="Copy code snippet"` to the button
- Dynamic `title` attribute for tooltip support (changes on click)
- Added an `aria-live="polite"` visually hidden span that announces "Copied code to clipboard" for screen readers
- Ensured it uses standard `<button>` element for keyboard focusability and interaction

---
*PR created automatically by Jules for task [2605389539042021186](https://jules.google.com/task/2605389539042021186) started by @balajirajput96*