### PR TITLE
🎨 Palette: Add copy buttons to Quickstart code blocks

### DIFF
--- a/src/components/landing/CodeBlock.tsx
+++ b/src/components/landing/CodeBlock.tsx
@@ -1,0 +1,97 @@
+import { useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+
+interface CodeBlockProps {
+  code: string;
+}
+
+export function CodeBlock({ code }: CodeBlockProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error('Failed to copy text: ', err);
+    }
+  };
+
+  return (
+    <div style={{ position: 'relative' }}>
+      <div style={{
+        background: 'var(--bg-color)',
+        border: '1px solid var(--border-color)',
+        borderRadius: '8px',
+        padding: '1rem',
+        paddingRight: '3rem',
+        fontFamily: 'var(--font-code)',
+        fontSize: '0.875rem',
+        color: 'var(--secondary-accent)',
+        overflowX: 'auto',
+        whiteSpace: 'pre'
+      }}>
+        {code}
+      </div>
+
+      <motion.button
+        whileHover={{ scale: 1.05, backgroundColor: 'var(--surface-hover)' }}
+        whileTap={{ scale: 0.95 }}
+        onClick={handleCopy}
+        aria-label="Copy code block"
+        title={copied ? "Copied!" : "Copy to clipboard"}
+        style={{
+          position: 'absolute',
+          top: '0.5rem',
+          right: '0.5rem',
+          background: 'var(--surface-color)',
+          border: '1px solid var(--border-color)',
+          borderRadius: '6px',
+          padding: '0.4rem',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          cursor: 'pointer',
+          color: 'var(--muted-color)',
+          transition: 'color 0.2s',
+          minWidth: '32px',
+          height: '32px'
+        }}
+      >
+        <AnimatePresence mode="wait">
+          {copied ? (
+            <motion.div
+              key="check"
+              initial={{ opacity: 0, scale: 0.5 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0, scale: 0.5 }}
+              style={{ color: 'var(--primary-accent)' }}
+            >
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <polyline points="20 6 9 17 4 12"></polyline>
+              </svg>
+            </motion.div>
+          ) : (
+            <motion.div
+              key="copy"
+              initial={{ opacity: 0, scale: 0.5 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0, scale: 0.5 }}
+            >
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+              </svg>
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </motion.button>
+
+      {/* Screen reader only announcement */}
+      <span aria-live="polite" style={{ position: 'absolute', width: '1px', height: '1px', padding: 0, margin: '-1px', overflow: 'hidden', clip: 'rect(0, 0, 0, 0)', whiteSpace: 'nowrap', borderWidth: 0 }}>
+        {copied ? "Copied to clipboard" : ""}
+      </span>
+    </div>
+  );
+}

--- a/src/components/landing/Quickstart.tsx
+++ b/src/components/landing/Quickstart.tsx
@@ -1,5 +1,6 @@
 import { motion } from 'framer-motion';
 import { SectionHeading } from './SectionHeading';
+import { CodeBlock } from './CodeBlock';
 
 export function Quickstart() {
   const steps = [
@@ -82,19 +83,7 @@ export function Quickstart() {
                 <h3 style={{ fontSize: '1.5rem', marginBottom: '0.5rem' }}>{step.title}</h3>
                 <p style={{ color: 'var(--muted-color)', marginBottom: '1.5rem' }}>{step.description}</p>
 
-                <div style={{
-                  background: 'var(--bg-color)',
-                  border: '1px solid var(--border-color)',
-                  borderRadius: '8px',
-                  padding: '1rem',
-                  fontFamily: 'var(--font-code)',
-                  fontSize: '0.875rem',
-                  color: 'var(--secondary-accent)',
-                  overflowX: 'auto',
-                  whiteSpace: 'pre'
-                }}>
-                  {step.code}
-                </div>
+                <CodeBlock code={step.code} />
               </div>
             </motion.div>
           ))}


### PR DESCRIPTION
💡 What: Extracted the inline code elements in the Quickstart section into a reusable `CodeBlock` component with a dedicated "copy to clipboard" button.
🎯 Why: Displaying setup instructions as static text requires users to manually select and copy them, adding friction to the onboarding process. Adding a dedicated copy action creates a more intuitive and seamless quickstart experience.
📸 Before/After: Verified visually via screenshot.
♿ Accessibility: Added `aria-label` to the icon-only button and an `aria-live` region to announce the "Copied" status to screen readers.

---
*PR created automatically by Jules for task [2106303350492009314](https://jules.google.com/task/2106303350492009314) started by @balajirajput96*