### PR TITLE
🎨 Palette: [UX improvement] Add interactive Copy button to Quickstart code snippets

### DIFF
--- a/src/components/landing/Quickstart.tsx
+++ b/src/components/landing/Quickstart.tsx
@@ -1,5 +1,114 @@
-import { motion } from 'framer-motion';
+import { useState, useEffect, useRef } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
 import { SectionHeading } from './SectionHeading';
+
+function CopyableCode({ code }: { code: string }) {
+  const [copied, setCopied] = useState(false);
+  const timeoutRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopied(true);
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+      timeoutRef.current = window.setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error('Failed to copy text: ', err);
+    }
+  };
+
+  return (
+    <div style={{
+      background: 'var(--bg-color)',
+      border: '1px solid var(--border-color)',
+      borderRadius: '8px',
+      padding: '0.75rem 1rem',
+      display: 'flex',
+      justifyContent: 'space-between',
+      alignItems: 'flex-start',
+      gap: '1rem',
+      position: 'relative'
+    }}>
+      <div style={{
+        fontFamily: 'var(--font-code)',
+        fontSize: '0.875rem',
+        color: 'var(--secondary-accent)',
+        overflowX: 'auto',
+        whiteSpace: 'pre',
+        scrollbarWidth: 'none',
+        flex: 1
+      }}>
+        {code}
+      </div>
+
+      <motion.button
+        whileHover={{ scale: 1.05, backgroundColor: 'var(--surface-hover)' }}
+        whileTap={{ scale: 0.95 }}
+        onClick={handleCopy}
+        aria-label="Copy code to clipboard"
+        title={copied ? "Copied!" : "Copy to clipboard"}
+        style={{
+          background: 'transparent',
+          border: '1px solid var(--border-color)',
+          borderRadius: '6px',
+          padding: '0.5rem',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          cursor: 'pointer',
+          color: 'var(--muted-color)',
+          transition: 'color 0.2s',
+          minWidth: '36px',
+          height: '36px',
+          flexShrink: 0
+        }}
+      >
+        <AnimatePresence mode="wait">
+          {copied ? (
+            <motion.div
+              key="check"
+              initial={{ opacity: 0, scale: 0.5 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0, scale: 0.5 }}
+              style={{ color: 'var(--primary-accent)' }}
+            >
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <polyline points="20 6 9 17 4 12"></polyline>
+              </svg>
+            </motion.div>
+          ) : (
+            <motion.div
+              key="copy"
+              initial={{ opacity: 0, scale: 0.5 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0, scale: 0.5 }}
+            >
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+              </svg>
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </motion.button>
+
+      {/* Screen reader only announcement */}
+      <span aria-live="polite" style={{ position: 'absolute', width: '1px', height: '1px', padding: 0, margin: '-1px', overflow: 'hidden', clip: 'rect(0, 0, 0, 0)', whiteSpace: 'nowrap', borderWidth: 0 }}>
+        {copied ? "Copied to clipboard" : ""}
+      </span>
+    </div>
+  );
+}
 
 export function Quickstart() {
   const steps = [
@@ -82,19 +191,7 @@ export function Quickstart() {
                 <h3 style={{ fontSize: '1.5rem', marginBottom: '0.5rem' }}>{step.title}</h3>
                 <p style={{ color: 'var(--muted-color)', marginBottom: '1.5rem' }}>{step.description}</p>
 
-                <div style={{
-                  background: 'var(--bg-color)',
-                  border: '1px solid var(--border-color)',
-                  borderRadius: '8px',
-                  padding: '1rem',
-                  fontFamily: 'var(--font-code)',
-                  fontSize: '0.875rem',
-                  color: 'var(--secondary-accent)',
-                  overflowX: 'auto',
-                  whiteSpace: 'pre'
-                }}>
-                  {step.code}
-                </div>
+                <CopyableCode code={step.code} />
               </div>
             </motion.div>
           ))}


### PR DESCRIPTION
💡 **What:** Added a `CopyableCode` component to the `Quickstart.tsx` section to replace static code text displays. This component includes a functional copy-to-clipboard button with a visual success state and animations.

🎯 **Why:** Users frequently need to copy installation commands or quickstart snippets. Adding a dedicated one-click copy button reduces friction, making it easier and faster for them to adopt the tool and start developing.

♿ **Accessibility:**
- Added an `aria-label` to the copy button for screen readers.
- Added a `title` attribute for tooltip support.
- Included an `aria-live="polite"` region that announces "Copied to clipboard" to screen readers when the action is successful, ensuring non-visual users receive confirmation.
- Safe keyboard focus management supported by existing button styles.

---
*PR created automatically by Jules for task [11653695138675823776](https://jules.google.com/task/11653695138675823776) started by @balajirajput96*