### PR TITLE
🎨 Palette: Fix Screen Reader Spam in TerminalPreview Typing Animation

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-07-21 - Screen Reader Spam from Typing Animations
+**Learning:** Animated text revealing itself character-by-character (like a terminal typing effect) causes screen readers to constantly announce DOM updates, creating a confusing and spammy experience for users.
+**Action:** When building decorative typing animations, hide the animated element from screen readers using `aria-hidden="true"`, and provide a static, visually hidden (`.sr-only`) equivalent of the final content that screen readers can parse at their own pace.

--- a/src/components/landing/TerminalPreview.tsx
+++ b/src/components/landing/TerminalPreview.tsx
@@ -78,6 +78,26 @@ export function TerminalPreview() {
     <section style={{ padding: '8rem 0' }}>
       <div className="container">
         <div style={{
+          position: 'absolute',
+          width: '1px',
+          height: '1px',
+          padding: 0,
+          margin: '-1px',
+          overflow: 'hidden',
+          clip: 'rect(0, 0, 0, 0)',
+          whiteSpace: 'nowrap',
+          borderWidth: 0
+        }}>
+          Terminal preview showing Antigravity CLI commands:
+          <ul>
+            {lines.map((line, i) => (
+              <li key={i}>
+                Command: {line.cmd}. Output: {line.out}
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div aria-hidden="true" style={{
           background: 'var(--bg-color)',
           border: '1px solid var(--border-color)',
           borderRadius: '12px',


### PR DESCRIPTION
*   **💡 What:** Added a visually hidden representation of the `TerminalPreview`'s content and hid the animated typing effect container from screen readers.
*   **🎯 Why:** Typing animations cause screen readers to announce every single character update as a DOM change, creating an incredibly spammy and confusing experience. Providing a static block of the final content provides a superior accessible experience.
*   **📸 Before/After:** Visually identical.
*   **♿ Accessibility:** Screen reader users can now read the full terminal preview content natively at their own pace without being spammed by the typing animation.

*(Note: Applied via inline styles to strictly adhere to the prompt's boundary of avoiding new custom CSS classes).*

---
*PR created automatically by Jules for task [14344917445136079339](https://jules.google.com/task/14344917445136079339) started by @balajirajput96*