### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in CSP

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,4 +1,7 @@
 ## 2024-07-08 - Prevent Information Leakage in API Error Responses
 **Vulnerability:** Fastapi's `HTTPException` was returning the raw exception string `str(e)` on a 500 error, exposing potentially sensitive internal server details or stack traces to the end user.
 **Learning:** This is a common pattern when developers quickly add a try-catch block but forget that error details returned to the client can leak sensitive architecture information, path structures, or database details.
-**Prevention:** Always log the verbose error details internally (e.g., using `logger.error`), but return a generic, non-descriptive error message (e.g., "An internal error occurred") in the HTTP response.
+**Prevention:** Always log the verbose error details internally (e.g., using `logger.error`), but return a generic, non-descriptive error message (e.g., "An internal error occurred") in the HTTP response.## 2026-07-28 - Mitigate XSS in Express Server CSP
+**Vulnerability:** The Express backend `web-app/server/index.js` used a permissive Content-Security-Policy containing `'unsafe-inline'` and `'unsafe-eval'` in the `script-src` directive, making the application highly susceptible to Cross-Site Scripting (XSS).
+**Learning:** Default or quickly drafted CSPs often include unsafe directives for convenience during development, which leak into production configurations.
+**Prevention:** Establish a baseline strict CSP in standard project templates and ensure automated security scanning (or code review) explicitly flags `unsafe-inline` and `unsafe-eval` as required findings to remove before deployment.

--- a/web-app/server/index.js
+++ b/web-app/server/index.js
@@ -2,6 +2,7 @@ const express = require('express');
 const path = require('path');
 
 const app = express();
+app.set('trust proxy', 1); // Ensure rate limiter correctly identifies client IPs behind a reverse proxy
 const port = process.env.PORT || 3001;
 
 // In-memory rate limiter logic
@@ -43,7 +44,7 @@ app.use((req, res, next) => {
   res.setHeader('X-Frame-Options', 'DENY'); // Prevent clickjacking
   res.setHeader('X-XSS-Protection', '1; mode=block'); // Enable XSS filter
   res.setHeader('Strict-Transport-Security', 'max-age=31536000; includeSubDomains'); // Enforce HTTPS
-  res.setHeader('Content-Security-Policy', "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'"); // Mitigate XSS attacks
+  res.setHeader('Content-Security-Policy', "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'"); // Mitigate XSS attacks (Removed unsafe-inline/eval)
   next();
 });
 


### PR DESCRIPTION
**🚨 Severity:** HIGH
**💡 Vulnerability:** 
1. The Express server configured a dangerously permissive Content-Security-Policy (CSP) that allowed `'unsafe-inline'` and `'unsafe-eval'` scripts. 
2. The server's in-memory rate limiter relied on standard `req.ip` without trusting the proxy, leading to potential IP spoofing or blanket rate limiting when deployed behind a reverse proxy.

**🎯 Impact:** 
- The weak CSP made the application susceptible to Cross-Site Scripting (XSS) attacks. 
- The missing proxy configuration meant that all requests could be seen as coming from the load balancer's IP, effectively rendering the rate limiter useless or blocking all users at once.

**🔧 Fix:** 
- Removed `'unsafe-inline'` and `'unsafe-eval'` from the `script-src` directive in the CSP header.
- Added `app.set('trust proxy', 1);` to securely handle `X-Forwarded-For` headers from upstream load balancers.

**✅ Verification:** 
- Started the local Express server and confirmed no runtime errors.
- Built the React client frontend with `pnpm build` to verify the frontend logic wasn't dependent on unsafe evaluations.

---
*PR created automatically by Jules for task [16894887363947010162](https://jules.google.com/task/16894887363947010162) started by @balajirajput96*