### PR TITLE
🎨 Palette: Add aria-hidden to decorative SVGs

### DIFF
--- a/src/components/landing/FAQ.tsx
+++ b/src/components/landing/FAQ.tsx
@@ -71,7 +71,7 @@ export function FAQ() {
                     animate={{ rotate: isOpen ? 180 : 0 }}
                     transition={{ duration: 0.2 }}
                   >
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--primary-accent)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--primary-accent)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                       <polyline points="6 9 12 15 18 9"></polyline>
                     </svg>
                   </motion.div>

--- a/src/components/landing/InstallCommand.tsx
+++ b/src/components/landing/InstallCommand.tsx
@@ -84,7 +84,7 @@ export function InstallCommand() {
               exit={{ opacity: 0, scale: 0.5 }}
               style={{ color: 'var(--primary-accent)' }}
             >
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <svg aria-hidden="true" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                 <polyline points="20 6 9 17 4 12"></polyline>
               </svg>
             </motion.div>
@@ -95,7 +95,7 @@ export function InstallCommand() {
               animate={{ opacity: 1, scale: 1 }}
               exit={{ opacity: 0, scale: 0.5 }}
             >
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <svg aria-hidden="true" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                 <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
                 <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
               </svg>


### PR DESCRIPTION
* 💡 **What**: Added `aria-hidden="true"` to decorative SVG icons within the `<FAQ>` and `<InstallCommand>` interactive components on the landing page.
* 🎯 **Why**: Decorative SVGs inside interactive elements like buttons can lead to redundant or confusing announcements by screen readers. Marking them as hidden ensures they are ignored by assistive technologies, resulting in a cleaner accessibility tree.
* 📸 **Before/After**: The visual appearance is identical. The change only affects the DOM's accessibility tree.
* ♿ **Accessibility**: Prevents screen readers from unnecessarily reading out SVG contents inside the accordion toggles and copy buttons, significantly improving keyboard and screen reader navigation clarity.

---
*PR created automatically by Jules for task [11642528849812969924](https://jules.google.com/task/11642528849812969924) started by @balajirajput96*