### PR TITLE
🎨 Palette: Add aria-hidden to decorative SVGs

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2023-10-27 - ARIA Controls on Framer Motion Components
 **Learning:** Expanding/collapsible regions managed by Framer Motion's `<AnimatePresence>` and `<motion.div>` don't natively map their relationships to toggle buttons for screen readers. In this codebase's FAQ section, toggles were missing `aria-controls` explicitly linking the toggle button to the target content container.
 **Action:** Always add explicit `id` to the `<motion.div>` target and matching `aria-controls={id}` to the corresponding toggle `<button>` when building or maintaining animated collapsible regions, especially since animation libraries don't enforce these semantic links.
+
+## 2024-08-14 - [UX] Decorative SVGs inside Interactive Elements
+**Learning:** Decorative icons (like SVG elements) inside interactive elements (buttons, toggles) or components with accompanying text will be redundantly announced by screen readers (e.g. as "graphic") if not explicitly hidden, creating unnecessary noise for visually impaired users.
+**Action:** Always add `aria-hidden="true"` to decorative SVGs when they are placed next to visible label text or title attributes to ensure a cleaner screen reader experience.

--- a/src/components/landing/FAQ.tsx
+++ b/src/components/landing/FAQ.tsx
@@ -71,7 +71,7 @@ export function FAQ() {
                     animate={{ rotate: isOpen ? 180 : 0 }}
                     transition={{ duration: 0.2 }}
                   >
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--primary-accent)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--primary-accent)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                       <polyline points="6 9 12 15 18 9"></polyline>
                     </svg>
                   </motion.div>

--- a/src/components/landing/Features.tsx
+++ b/src/components/landing/Features.tsx
@@ -7,7 +7,7 @@ export function Features() {
       title: 'Zero Config',
       description: 'Start working immediately with sensible defaults. No complex setup files or boilerplate required.',
       icon: (
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
           <path d="M12 2v20M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/>
         </svg>
       )
@@ -16,7 +16,7 @@ export function Features() {
       title: 'Cross Platform',
       description: 'Write once, run anywhere. Seamlessly works across macOS, Windows, and Linux environments.',
       icon: (
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
           <rect x="2" y="3" width="20" height="14" rx="2" ry="2"/>
           <line x1="8" y1="21" x2="16" y2="21"/>
           <line x1="12" y1="17" x2="12" y2="21"/>
@@ -27,7 +27,7 @@ export function Features() {
       title: 'Blazing Fast',
       description: 'Built with Rust for near-instant execution. Commands complete before you even lift your finger.',
       icon: (
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
           <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/>
         </svg>
       )
@@ -36,7 +36,7 @@ export function Features() {
       title: 'Plugin Ecosystem',
       description: 'Extend functionality infinitely. Tap into a vibrant community of plugins or easily author your own.',
       icon: (
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
           <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/>
           <polyline points="3.27 6.96 12 12.01 20.73 6.96"/>
           <line x1="12" y1="22.08" x2="12" y2="12"/>

--- a/src/components/landing/InstallCommand.tsx
+++ b/src/components/landing/InstallCommand.tsx
@@ -84,7 +84,7 @@ export function InstallCommand() {
               exit={{ opacity: 0, scale: 0.5 }}
               style={{ color: 'var(--primary-accent)' }}
             >
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <svg aria-hidden="true" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                 <polyline points="20 6 9 17 4 12"></polyline>
               </svg>
             </motion.div>
@@ -95,7 +95,7 @@ export function InstallCommand() {
               animate={{ opacity: 1, scale: 1 }}
               exit={{ opacity: 0, scale: 0.5 }}
             >
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <svg aria-hidden="true" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                 <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
                 <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
               </svg>


### PR DESCRIPTION
### 💡 What
Added `aria-hidden="true"` to all decorative `<svg>` icons used in the `FAQ`, `InstallCommand`, and `Features` components.

### 🎯 Why
These SVG elements are decorative—they either accompany visible textual content (like headings or paragraphs) or visual indicators for interactive elements (like the checkmark when copying the install command). By default, screen readers might announce these SVGs as "graphic" or try to read their internal path strings, adding unnecessary noise for visually impaired users.

### 📸 Before/After
Visually, the components remain exactly the same. The change exclusively affects the semantic accessibility tree.

### ♿ Accessibility
This change improves the accessibility score by preventing screen readers from redundantly announcing decorative icons, offering a much cleaner navigation experience for keyboard and screen reader users navigating the landing page features.

---
*PR created automatically by Jules for task [6046867157493125273](https://jules.google.com/task/6046867157493125273) started by @balajirajput96*