### PR TITLE
🎨 Palette: Enhance screen reader experience for decorative elements

### DIFF
--- a/src/components/landing/TerminalPreview.tsx
+++ b/src/components/landing/TerminalPreview.tsx
@@ -37,13 +37,13 @@ const TERMINAL_HEADER = (
 // objects on every frame, saving CPU cycles.
 const TERMINAL_PROMPT = (
   <>
-    <span style={{ color: 'var(--primary-accent)' }}>~</span>
-    <span style={{ color: 'var(--secondary-accent)' }}>$</span>
+    <span aria-hidden="true" style={{ color: 'var(--primary-accent)' }}>~</span>
+    <span aria-hidden="true" style={{ color: 'var(--secondary-accent)' }}>$</span>
   </>
 );
 
 const TERMINAL_CURSOR = (
-  <span className="cursor-blink" style={{
+  <span aria-hidden="true" className="cursor-blink" style={{
     display: 'inline-block',
     width: '8px',
     height: '15px',


### PR DESCRIPTION
💡 **What**: Added `aria-hidden="true"` to decorative SVG icons in the features section and to purely decorative text symbols (like terminal prompts `~` and `$`) in the terminal preview and install command components.

🎯 **Why**: Screen readers naturally try to read out these symbols (e.g., "tilde dollar sign curl..."), which creates unnecessary noise for visually impaired users. This change ensures screen readers skip over purely decorative visual elements, making the actual content more accessible and easier to comprehend.

📸 **Before/After**: Visually, the UI remains identical since this is purely an accessibility tree enhancement.

♿ **Accessibility**: Prevents screen readers from announcing decorative SVGs and text symbols, significantly improving the signal-to-noise ratio for visually impaired users navigating the landing page.

---
*PR created automatically by Jules for task [15435037393453673065](https://jules.google.com/task/15435037393453673065) started by @balajirajput96*