### PR TITLE
🎨 Palette: Hide decorative terminal prompts from screen readers

### DIFF
--- a/src/components/landing/TerminalPreview.tsx
+++ b/src/components/landing/TerminalPreview.tsx
@@ -37,13 +37,13 @@ const TERMINAL_HEADER = (
 // objects on every frame, saving CPU cycles.
 const TERMINAL_PROMPT = (
   <>
-    <span style={{ color: 'var(--primary-accent)' }}>~</span>
-    <span style={{ color: 'var(--secondary-accent)' }}>$</span>
+    <span aria-hidden="true" style={{ color: 'var(--primary-accent)' }}>~</span>
+    <span aria-hidden="true" style={{ color: 'var(--secondary-accent)' }}>$</span>
   </>
 );
 
 const TERMINAL_CURSOR = (
-  <span className="cursor-blink" style={{
+  <span aria-hidden="true" className="cursor-blink" style={{
     display: 'inline-block',
     width: '8px',
     height: '15px',


### PR DESCRIPTION
### 💡 What
Added `aria-hidden="true"` to the decorative terminal prompt characters (`~` and `$`) in the `TerminalPreview` and `InstallCommand` components.

### 🎯 Why
Screen readers will read out these text characters aloud (e.g. "tilde dollar sign ag init"), which adds unnecessary noise to the core command information the user actually needs.

### 📸 Before/After
*(Visuals remain unchanged)*

### ♿ Accessibility
Improves the screen reader experience by making decorative terminal prompts invisible to assistive technologies, allowing users to focus purely on the command string.

---
*PR created automatically by Jules for task [14706614552957782281](https://jules.google.com/task/14706614552957782281) started by @balajirajput96*