### PR TITLE
🎨 Palette: Accessibility improvement for Terminal Preview

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@
 ## 2024-07-14 - Playwright Verification with Client-Side Routing
 **Learning:** Using `file://` to load the built index.html for Playwright testing fails because TanStack Router requires a proper server for client-side routing to function, otherwise elements like 'text=Defy gravity' won't render.
 **Action:** Always start a local server (e.g. `pnpm preview` on port 4173) and test against `http://localhost:4173` when verifying frontend changes in apps using client-side routing.
+
+## 2024-05-14 - Redundant screen reader announcements in mock terminals
+**Learning:** Purely decorative text characters used to simulate terminal UI elements (like `~` and `$` command prompts, or fake blinking cursors) are read aloud by screen readers, creating noisy and frustrating user experiences ("tilde dollar sign ag init").
+**Action:** Always add `aria-hidden="true"` to spans containing decorative terminal symbols or cursors that do not convey functional information, prioritizing the actual command text instead.

--- a/src/components/landing/TerminalPreview.tsx
+++ b/src/components/landing/TerminalPreview.tsx
@@ -11,7 +11,7 @@ const lines = [
 ];
 
 const TERMINAL_HEADER = (
-  <div style={{
+  <div aria-hidden="true" style={{
     background: 'var(--surface-color)',
     padding: '0.75rem 1rem',
     borderBottom: '1px solid var(--border-color)',
@@ -37,13 +37,13 @@ const TERMINAL_HEADER = (
 // objects on every frame, saving CPU cycles.
 const TERMINAL_PROMPT = (
   <>
-    <span style={{ color: 'var(--primary-accent)' }}>~</span>
-    <span style={{ color: 'var(--secondary-accent)' }}>$</span>
+    <span aria-hidden="true" style={{ color: 'var(--primary-accent)' }}>~</span>
+    <span aria-hidden="true" style={{ color: 'var(--secondary-accent)' }}>$</span>
   </>
 );
 
 const TERMINAL_CURSOR = (
-  <span className="cursor-blink" style={{
+  <span aria-hidden="true" className="cursor-blink" style={{
     display: 'inline-block',
     width: '8px',
     height: '15px',


### PR DESCRIPTION
What:
Added `aria-hidden="true"` to purely decorative elements within the `TerminalPreview.tsx` component, including the mock window header dots, the `~` and `$` prompt characters, and the simulated blinking cursor spans.

Why:
These elements were being read aloud by screen readers (e.g., "tilde dollar sign ag init"), creating a noisy, redundant, and frustrating auditory experience for users relying on assistive technologies.

Before/After:
Before: Screen readers would announce decorative punctuation.
After: Screen readers will skip the decorative symbols and only read the functional command and output text (e.g., "ag init").

Accessibility:
Improves screen reader clarity and reduces cognitive overload for users navigating the mock terminal block.

---
*PR created automatically by Jules for task [15637809037204757907](https://jules.google.com/task/15637809037204757907) started by @balajirajput96*