### PR TITLE
⚡ Bolt: Extract static JSX to prevent frequent reconciliation diffing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -19,3 +19,6 @@
 ## 2024-05-14 - React Animation State Updates Causing Unnecessary Re-renders
 **Learning:** High-frequency state updates (like typing animations using `setInterval` every 100ms) will trigger a full component re-render. If the component also renders a mapped list (like previous terminal lines), these elements will be needlessly recreated and reconciled on every frame of the animation, causing unnecessary CPU overhead and potential jank, even if they don't change.
 **Action:** Extract constant data arrays outside the component scope to avoid reallocation, and use `useMemo` to memoize the rendering of list elements that depend on a slow-changing state (e.g. `currentLine`) so they are isolated from the fast-changing state (e.g. `text` for the typing animation).
+## 2024-08-18 - Prevent Frequent Reconciliation in React Animation Loops
+**Learning:** In a codebase implementing custom text typing animations via rapid `setInterval` state updates (e.g., every 100ms in `TerminalPreview.tsx`), inline static JSX elements trigger unnecessary object allocations and diffing overhead on every tick.
+**Action:** Extract fully static, frequently rendered JSX subtrees into constants defined *outside* the component function to ensure they are created only once, allowing React's reconciler to completely bypass them during rapid render cycles.


### PR DESCRIPTION
💡 **What:** Extracted the static, frequently-used JSX blocks (the terminal prompt `~ $` symbols and the blinking cursor `|` span) entirely outside the `TerminalPreview` component function into constants `TERMINAL_PROMPT` and `CURSOR_BLINK`. Added comments explaining the optimization.

🎯 **Why:** The `TerminalPreview` component contains a text typing animation that uses `setInterval` to trigger state updates every 100 milliseconds. Previously, inline static JSX elements were re-created on every single render tick, causing unnecessary object allocations and forcing React's reconciliation engine to diff these identical subtrees constantly.

📊 **Impact:** By defining these static React Elements completely outside the component function, they are created exactly once in memory. This eliminates unnecessary object allocations and allows React to completely bypass diffing these specific subtrees during the rapid 100ms render cycles, improving performance and reducing overhead.

🔬 **Measurement:** The project builds cleanly with `npx tsc --noEmit && pnpm build`. Visual verification using Playwright confirms that the terminal text animation and cursor behavior still look and work flawlessly.

---
*PR created automatically by Jules for task [6481584335895143201](https://jules.google.com/task/6481584335895143201) started by @balajirajput96*