### PR TITLE
fix: harden job outreach URL fetch guard

### DIFF
--- a/job-outreach/automation/run_repo.py
+++ b/job-outreach/automation/run_repo.py
@@ -25,6 +25,7 @@ DASHBOARD = HERE / "dashboard.md"
 MODEL = os.getenv("LLM_MODEL", "openai/gpt-4o-mini")
 SCORE_THRESHOLD = int(os.getenv("SCORE_THRESHOLD", "55"))
 MAX_POSTS_PER_LISTING = int(os.getenv("MAX_POSTS_PER_LISTING", "12"))
+MAX_FETCH_REDIRECTS = 3
 
 DIAG = []   # human-readable diagnostics surfaced into dashboard.md
 
@@ -61,36 +62,67 @@ def prompt(name):
     return (HERE / "prompts" / f"{name}.md").read_text(encoding="utf-8")
 
 
+def is_public_address(address):
+    ip = ipaddress.ip_address(address)
+    return not any((
+        ip.is_private,
+        ip.is_loopback,
+        ip.is_link_local,
+        ip.is_multicast,
+        ip.is_unspecified,
+        ip.is_reserved,
+    ))
+
+
 def is_safe_url(url):
     try:
         parsed = urlparse(url)
         if parsed.scheme not in ('http', 'https'):
             return False
         hostname = parsed.hostname
-        if not hostname:
+        if not hostname or parsed.username or parsed.password:
             return False
-        ip = socket.gethostbyname(hostname)
-        ip_obj = ipaddress.ip_address(ip)
-        if ip_obj.is_private or ip_obj.is_loopback or ip_obj.is_link_local:
+        if parsed.port not in (None, 80, 443):
             return False
-        return True
+        addresses = {item[4][0] for item in socket.getaddrinfo(hostname, None, type=socket.SOCK_STREAM)}
+        return bool(addresses) and all(is_public_address(address) for address in addresses)
     except Exception:
         return False
 
+
 def fetch_html(url):
-    if not is_safe_url(url):
-        DIAG.append(f"fetch BLOCKED (unsafe URL): {url}")
-        print(f"  ! fetch blocked (unsafe URL): {url}")
-        return ""
-    try:
-        r = session.get(url, timeout=45, headers={"User-Agent": "Mozilla/5.0"})
-        if r.status_code != 200:
-            DIAG.append(f"fetch HTTP {r.status_code}: {url}")
-        return r.text
-    except Exception as e:
-        DIAG.append(f"fetch ERROR {url}: {e}")
-        print(f"  ! fetch failed {url}: {e}")
-        return ""
+    current_url = url
+    for _ in range(MAX_FETCH_REDIRECTS + 1):
+        if not is_safe_url(current_url):
+            DIAG.append(f"fetch BLOCKED (unsafe URL): {current_url}")
+            print(f"  ! fetch blocked (unsafe URL): {current_url}")
+            return ""
+        try:
+            response = session.get(
+                current_url,
+                timeout=45,
+                headers={"User-Agent": "Mozilla/5.0"},
+                allow_redirects=False,
+            )
+        except Exception as e:
+            DIAG.append(f"fetch ERROR {current_url}: {e}")
+            print(f"  ! fetch failed {current_url}: {e}")
+            return ""
+
+        if response.status_code in (301, 302, 303, 307, 308):
+            location = response.headers.get("Location")
+            if not location:
+                DIAG.append(f"fetch BLOCKED (redirect without location): {current_url}")
+                return ""
+            current_url = urljoin(current_url, location)
+            continue
+
+        if response.status_code != 200:
+            DIAG.append(f"fetch HTTP {response.status_code}: {current_url}")
+        return response.text
+
+    DIAG.append(f"fetch BLOCKED (too many redirects): {url}")
+    return ""
 
 
 def to_text(html):

--- a/job-outreach/automation/test_url_safety.py
+++ b/job-outreach/automation/test_url_safety.py
@@ -1,0 +1,54 @@
+import importlib.util
+import pathlib
+import socket
+import unittest
+from unittest.mock import patch
+
+
+MODULE_PATH = pathlib.Path(__file__).with_name("run_repo.py")
+SPEC = importlib.util.spec_from_file_location("run_repo", MODULE_PATH)
+run_repo = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(run_repo)
+
+
+class FakeResponse:
+    def __init__(self, status_code, text="", headers=None):
+        self.status_code = status_code
+        self.text = text
+        self.headers = headers or {}
+
+
+class UrlSafetyTests(unittest.TestCase):
+    def setUp(self):
+        run_repo.DIAG.clear()
+
+    @patch.object(run_repo.socket, "getaddrinfo")
+    def test_rejects_any_private_address_from_multi_address_dns(self, getaddrinfo):
+        getaddrinfo.return_value = [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0)),
+            (socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("::1", 0, 0, 0)),
+        ]
+
+        self.assertFalse(run_repo.is_safe_url("https://jobs.example.com"))
+
+    @patch.object(run_repo.socket, "getaddrinfo")
+    def test_accepts_only_global_http_addresses_on_standard_ports(self, getaddrinfo):
+        getaddrinfo.return_value = [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0)),
+        ]
+
+        self.assertTrue(run_repo.is_safe_url("https://jobs.example.com/openings"))
+        self.assertFalse(run_repo.is_safe_url("https://jobs.example.com:8080/openings"))
+
+    @patch.object(run_repo.session, "get")
+    @patch.object(run_repo, "is_safe_url", side_effect=lambda url: url == "https://jobs.example.com/openings")
+    def test_rejects_redirect_to_private_network_before_following(self, is_safe_url, get):
+        get.return_value = FakeResponse(302, headers={"Location": "http://127.0.0.1/admin"})
+
+        self.assertEqual(run_repo.fetch_html("https://jobs.example.com/openings"), "")
+        get.assert_called_once()
+        self.assertIn("fetch BLOCKED (unsafe URL): http://127.0.0.1/admin", run_repo.DIAG)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary: extends PR #87 by resolving all DNS answers (including IPv6), rejecting every non-global address class and credentials/non-standard ports, and manually revalidating each redirect before following it. Added three focused regression tests for mixed public/private DNS, standard-port restrictions, and redirects to loopback. Validation: python3 -m unittest test_url_safety.py (3 passing); python3 -m py_compile; git diff --check.