### PR TITLE
⚡ Bolt: Extract static JSX to prevent constant reallocation during TerminalPreview animation

### DIFF
--- a/src/components/landing/TerminalPreview.tsx
+++ b/src/components/landing/TerminalPreview.tsx
@@ -28,6 +28,31 @@ const TERMINAL_HEADER = (
   </div>
 );
 
+// PERFORMANCE OPTIMIZATION:
+// Extract purely static UI elements (prompt and cursor) completely outside
+// the component function. Because TerminalPreview uses a high-frequency
+// interval to update state (`text` and `currentLine`) for the typing animation,
+// it re-renders constantly. Hoisting these elements prevents React from
+// continuously re-allocating and diffing these nodes and their inline style
+// objects on every frame, saving CPU cycles.
+const TERMINAL_PROMPT = (
+  <>
+    <span style={{ color: 'var(--primary-accent)' }}>~</span>
+    <span style={{ color: 'var(--secondary-accent)' }}>$</span>
+  </>
+);
+
+const TERMINAL_CURSOR = (
+  <span className="cursor-blink" style={{
+    display: 'inline-block',
+    width: '8px',
+    height: '15px',
+    background: 'var(--fg-color)',
+    marginLeft: '2px',
+    verticalAlign: 'middle'
+  }} />
+);
+
 export function TerminalPreview() {
   const [currentLine, setCurrentLine] = useState(0);
   const [text, setText] = useState('');
@@ -41,8 +66,7 @@ export function TerminalPreview() {
         style={{ marginBottom: '1rem' }}
       >
         <div style={{ display: 'flex', gap: '1rem' }}>
-          <span style={{ color: 'var(--primary-accent)' }}>~</span>
-          <span style={{ color: 'var(--secondary-accent)' }}>$</span>
+          {TERMINAL_PROMPT}
           <span style={{ color: 'var(--fg-color)' }}>{line.cmd}</span>
         </div>
         <div style={{ color: 'var(--muted-color)', paddingLeft: '2rem' }}>
@@ -102,34 +126,18 @@ export function TerminalPreview() {
 
             {currentLine < lines.length && (
               <div style={{ display: 'flex', gap: '1rem' }}>
-                <span style={{ color: 'var(--primary-accent)' }}>~</span>
-                <span style={{ color: 'var(--secondary-accent)' }}>$</span>
+                {TERMINAL_PROMPT}
                 <span style={{ color: 'var(--fg-color)' }}>
                   {text}
-                  <span className="cursor-blink" style={{
-                    display: 'inline-block',
-                    width: '8px',
-                    height: '15px',
-                    background: 'var(--fg-color)',
-                    marginLeft: '2px',
-                    verticalAlign: 'middle'
-                  }} />
+                  {TERMINAL_CURSOR}
                 </span>
               </div>
             )}
 
             {currentLine >= lines.length && (
               <div style={{ display: 'flex', gap: '1rem' }}>
-                <span style={{ color: 'var(--primary-accent)' }}>~</span>
-                <span style={{ color: 'var(--secondary-accent)' }}>$</span>
-                <span className="cursor-blink" style={{
-                  display: 'inline-block',
-                  width: '8px',
-                  height: '15px',
-                  background: 'var(--fg-color)',
-                  marginLeft: '2px',
-                  verticalAlign: 'middle'
-                }} />
+                {TERMINAL_PROMPT}
+                {TERMINAL_CURSOR}
               </div>
             )}
           </div>


### PR DESCRIPTION
💡 What: Extracted the terminal prompt (`~ $`) and the blinking cursor `span` into constant variables (`TERMINAL_PROMPT` and `TERMINAL_CURSOR`) completely outside the `TerminalPreview` component function. Added an explanatory comment detailing the optimization rationale.
🎯 Why: Because the `TerminalPreview` component drives a typing animation via a high-frequency `setInterval` (updating `text` and `currentLine` state every 100ms), the component re-renders continuously. When these static JSX elements and their complex inline style objects are defined inside the return block, React is forced to continuously re-allocate and diff these nodes on every frame, wasting CPU cycles and potentially causing jank. Hoisting them ensures they are allocated exactly once, allowing React's reconciler to bail out of diffing them via strict equality (`oldElement === newElement`).
📊 Impact: Eliminates continuous reallocation and diffing of two static JSX subtrees (one of which is mapped inside an array) during the typing animation, reducing unnecessary CPU overhead by the React reconciler and improving frame stability.
🔬 Measurement: Verified functionality by launching the dev server and recording the terminal typing animation via a Playwright script. The rendering and styling of the prompt and cursor remain visually identical, confirming the safety of the extraction. Run `pnpm build` to verify type safety.

---
*PR created automatically by Jules for task [330598731153857163](https://jules.google.com/task/330598731153857163) started by @balajirajput96*