### PR TITLE
🎨 Palette: Hide decorative terminal elements from screen readers

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2024-05-18 - Hide Decorative Terminal Elements
+**Learning:** Terminal-style UI components often include purely decorative characters like `~` and `$` as part of the prompt line, as well as decorative blinking cursors. If these are not explicitly hidden from screen readers, they result in redundant and confusing voiceover announcements (e.g., "tilde dollar sign ag init").
+**Action:** Always explicitly add `aria-hidden="true"` to purely decorative text symbols (like terminal prompts) and decorative elements (like custom text cursors) that provide no semantic value to screen reader users.

--- a/src/components/landing/TerminalPreview.tsx
+++ b/src/components/landing/TerminalPreview.tsx
@@ -37,13 +37,13 @@ const TERMINAL_HEADER = (
 // objects on every frame, saving CPU cycles.
 const TERMINAL_PROMPT = (
   <>
-    <span style={{ color: 'var(--primary-accent)' }}>~</span>
-    <span style={{ color: 'var(--secondary-accent)' }}>$</span>
+    <span aria-hidden="true" style={{ color: 'var(--primary-accent)' }}>~</span>
+    <span aria-hidden="true" style={{ color: 'var(--secondary-accent)' }}>$</span>
   </>
 );
 
 const TERMINAL_CURSOR = (
-  <span className="cursor-blink" style={{
+  <span aria-hidden="true" className="cursor-blink" style={{
     display: 'inline-block',
     width: '8px',
     height: '15px',


### PR DESCRIPTION
💡 **What:** Added `aria-hidden="true"` to the decorative terminal prompt characters (`~` and `$`) and the blinking cursor in the `TerminalPreview.tsx` component. Added a new journal entry to `.jules/palette.md` detailing this codebase-specific learning.

🎯 **Why:** Screen readers will mistakenly announce purely decorative elements if they are constructed from text characters. When VoiceOver reads the terminal preview component, it will narrate "tilde dollar sign ag init", which creates a poor, confusing experience for users relying on assistive technology. Hiding these elements keeps the visual presentation identical while improving semantic clarity.

📸 **Before/After:** The visual output is identical.
*(See attached automated Playwright verification screenshots and video demonstrating the UI remains fully intact with the changes).*

♿ **Accessibility:** Prevents redundant and unhelpful voiceover announcements in the simulated terminal interface.

---
*PR created automatically by Jules for task [2009393453827565388](https://jules.google.com/task/2009393453827565388) started by @balajirajput96*