### PR TITLE
🎨 Palette: Improve terminal preview accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Accessibility for Terminal Mocks
+**Learning:** Terminal preview components and mockups often use non-semantic text symbols like `~`, `$`, and `—` for decorative shell prompts and window chrome, which create redundant or confusing screen reader announcements.
+**Action:** When implementing terminal mockups, ensure purely decorative text elements and symbols are explicitly hidden using `aria-hidden="true"`, and apply `user-select: none` to prevent them from being copied alongside commands.

--- a/src/components/landing/TerminalPreview.tsx
+++ b/src/components/landing/TerminalPreview.tsx
@@ -11,7 +11,7 @@ const lines = [
 ];
 
 const TERMINAL_HEADER = (
-  <div style={{
+  <div aria-hidden="true" style={{
     background: 'var(--surface-color)',
     padding: '0.75rem 1rem',
     borderBottom: '1px solid var(--border-color)',
@@ -36,14 +36,14 @@ const TERMINAL_HEADER = (
 // continuously re-allocating and diffing these nodes and their inline style
 // objects on every frame, saving CPU cycles.
 const TERMINAL_PROMPT = (
-  <>
+  <div aria-hidden="true" style={{ display: 'inline-flex', userSelect: 'none' }}>
     <span style={{ color: 'var(--primary-accent)' }}>~</span>
     <span style={{ color: 'var(--secondary-accent)' }}>$</span>
-  </>
+  </div>
 );
 
 const TERMINAL_CURSOR = (
-  <span className="cursor-blink" style={{
+  <span aria-hidden="true" className="cursor-blink" style={{
     display: 'inline-block',
     width: '8px',
     height: '15px',


### PR DESCRIPTION
**💡 What:**
Added `aria-hidden="true"` to purely decorative visual elements in the terminal preview mockup, including the top window controls (`TERMINAL_HEADER`), the blinking cursor (`TERMINAL_CURSOR`), and the shell prompt symbols (`TERMINAL_PROMPT`). Also explicitly wrapped the prompt symbols in a `div` and applied `userSelect: 'none'`.

**🎯 Why:**
Terminal mockups commonly use non-semantic ASCII characters like `~` and `$` to simulate shell prompts. Screen readers often announce these characters redundantly on every single line, creating significant noise and confusion for assistive technology users. Furthermore, when users attempt to highlight and copy the command blocks, the prompt characters are often accidentally included in their clipboard. Hiding these visual elements from screen readers and text-selection prevents both issues.

**📸 Before/After:**
*(No visual changes - rendering matches exactly. Verified via local Playwright snapshot tests.)*

**♿ Accessibility:**
* Added `aria-hidden="true"` to stop screen readers from announcing repeating terminal decorators.
* Improved copy-paste usability via `user-select: none`.
* No changes were made to the actual command text or application output strings, ensuring the functional content remains perfectly readable to assistive technology.

---
*PR created automatically by Jules for task [11060186324572783989](https://jules.google.com/task/11060186324572783989) started by @balajirajput96*