### PR TITLE
🎨 Palette: Prevent accidental copying of terminal prompt symbols

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-08-22 - Prevent copying terminal prompt symbols
+**Learning:** Terminal components often use symbols like `~` and `$` to simulate command prompts. If these are selectable, users who copy-paste commands will accidentally include these symbols, breaking their scripts. Screen readers also read them out redundantly.
+**Action:** Always add `userSelect: "none"` and `aria-hidden="true"` to decorative terminal prompt symbols to ensure smooth copying and a11y.

--- a/src/components/landing/TerminalPreview.tsx
+++ b/src/components/landing/TerminalPreview.tsx
@@ -11,13 +11,14 @@ const lines = [
 ];
 
 const TERMINAL_HEADER = (
-  <div style={{
+  <div aria-hidden="true" style={{
     background: 'var(--surface-color)',
     padding: '0.75rem 1rem',
     borderBottom: '1px solid var(--border-color)',
     display: 'flex',
     alignItems: 'center',
-    gap: '0.5rem'
+    gap: '0.5rem',
+    userSelect: 'none'
   }}>
     <div style={{ width: '12px', height: '12px', borderRadius: '50%', background: '#ff5f56' }} />
     <div style={{ width: '12px', height: '12px', borderRadius: '50%', background: '#ffbd2e' }} />
@@ -36,14 +37,14 @@ const TERMINAL_HEADER = (
 // continuously re-allocating and diffing these nodes and their inline style
 // objects on every frame, saving CPU cycles.
 const TERMINAL_PROMPT = (
-  <>
+  <span aria-hidden="true" style={{ userSelect: 'none' }}>
     <span style={{ color: 'var(--primary-accent)' }}>~</span>
     <span style={{ color: 'var(--secondary-accent)' }}>$</span>
-  </>
+  </span>
 );
 
 const TERMINAL_CURSOR = (
-  <span className="cursor-blink" style={{
+  <span aria-hidden="true" className="cursor-blink" style={{
     display: 'inline-block',
     width: '8px',
     height: '15px',


### PR DESCRIPTION
💡 What: Added `aria-hidden="true"` and `userSelect: 'none'` to the purely decorative terminal prompt symbols (`~`, `$`) and header, and `aria-hidden="true"` to the cursor.
🎯 Why: When users try to highlight and copy terminal commands, they can accidentally copy the decorative prompt symbols, which breaks their scripts. Screen readers also read these symbols out redundantly.
📸 Before/After: Visuals look identical, but highlighting text in the terminal window no longer catches the `~ $` or the header elements.
♿ Accessibility: The screen reader experience is improved because it skips over the purely visual "tilde dollar sign" and structural header noise, focusing on the actual commands and outputs.

---
*PR created automatically by Jules for task [4413096080547669165](https://jules.google.com/task/4413096080547669165) started by @balajirajput96*