### PR TITLE
🎨 Palette: Improve terminal prompt accessibility and UX

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-08-23 - Terminal Prompt Accessibility
+**Learning:** Decorative terminal characters like '~' and '$' should have `userSelect: 'none'` and `aria-hidden='true'` to prevent screen reader noise and accidental copying.
+**Action:** Always add these attributes to decorative prompt characters in terminal or code block components.

--- a/src/components/landing/TerminalPreview.tsx
+++ b/src/components/landing/TerminalPreview.tsx
@@ -37,13 +37,13 @@ const TERMINAL_HEADER = (
 // objects on every frame, saving CPU cycles.
 const TERMINAL_PROMPT = (
   <>
-    <span style={{ color: 'var(--primary-accent)' }}>~</span>
-    <span style={{ color: 'var(--secondary-accent)' }}>$</span>
+    <span aria-hidden="true" style={{ color: 'var(--primary-accent)', userSelect: 'none' }}>~</span>
+    <span aria-hidden="true" style={{ color: 'var(--secondary-accent)', userSelect: 'none' }}>$</span>
   </>
 );
 
 const TERMINAL_CURSOR = (
-  <span className="cursor-blink" style={{
+  <span aria-hidden="true" className="cursor-blink" style={{
     display: 'inline-block',
     width: '8px',
     height: '15px',


### PR DESCRIPTION
💡 **What:** Added `userSelect: 'none'` and `aria-hidden="true"` to decorative characters in the `TerminalPreview` component.
🎯 **Why:** To prevent accidental text selection of prompt symbols (a common developer annoyance) and to eliminate redundant screen reader announcements (e.g. "tilde dollar").
📸 **Before/After:** Visually identical, but the `~` and `$` are no longer highlightable.
♿ **Accessibility:** Screen readers will now skip the purely decorative prompt characters and cursor.

---
*PR created automatically by Jules for task [2392784400057139900](https://jules.google.com/task/2392784400057139900) started by @balajirajput96*