### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal/SSRF risk in GitHub endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -9,3 +9,7 @@
 **Vulnerability:** The FastAPI endpoint `/predict` accepted a `List[float]` without length constraints in `PredictionInput`. A malicious user could send an excessively large list (e.g., millions of items), causing the application to consume excessive memory leading to a Denial of Service (DoS) attack.
 **Learning:** This is a common oversight when defining Pydantic schemas. By default, unbounded iterables (Lists, Dicts, Sets) lack size limits, making endpoints that deserialize large payloads vulnerable to resource exhaustion.
 **Prevention:** Constrain collections and iterables in Pydantic schemas using `Field(..., max_length=N)` where N represents a reasonable, expected upper bound for the business logic.
+## 2024-05-18 - SSRF and Path Traversal in GitHub Endpoint
+**Vulnerability:** The Express backend used URL parameters (`owner`, `repo`) without validation in `axios` requests to external APIs (GitHub).
+**Learning:** `req.params` inputs are untrusted and URL-encoded characters (like `%2F` for `/`) can be passed to external APIs causing path traversal or Server-Side Request Forgery if the external service handles path elements insecurely.
+**Prevention:** Strictly validate external-facing URL parameters using strict regexes (e.g., `/^[a-zA-Z0-9_.-]+$/`) before passing them to internal service requests.

--- a/web-app/server/index.js
+++ b/web-app/server/index.js
@@ -76,6 +76,9 @@ app.get('/api/youtube', (req, res) => res.json({ message: 'YouTube API endpoint'
 app.get('/api/google-drive', (req, res) => res.json({ message: 'Google Drive API endpoint' }));
 
 app.get('/api/github/repos/:owner', async (req, res) => {
+  if (!/^[a-zA-Z0-9_.-]+$/.test(req.params.owner)) {
+    return res.status(400).json({ error: 'Invalid owner parameter.' });
+  }
   try {
     const response = await githubApi.get(`/users/${req.params.owner}/repos`);
     return res.json(response.data);
@@ -85,6 +88,9 @@ app.get('/api/github/repos/:owner', async (req, res) => {
 });
 
 app.post('/api/github/issues/:owner/:repo', async (req, res) => {
+  if (!/^[a-zA-Z0-9_.-]+$/.test(req.params.owner) || !/^[a-zA-Z0-9_.-]+$/.test(req.params.repo)) {
+    return res.status(400).json({ error: 'Invalid owner or repo parameter.' });
+  }
   const { title, body } = req.body || {};
   if (!title) return res.status(400).json({ error: 'title is required.' });
   try {


### PR DESCRIPTION
🚨 **Severity:** HIGH

💡 **Vulnerability:** The GitHub API endpoints `/api/github/repos/:owner` and `/api/github/issues/:owner/:repo` directly pass user-provided URL parameters to downstream external GitHub API requests via `axios` without any validation. This allows attackers to potentially use path traversal characters (like `%2F` / `/`) to manipulate the external API endpoint being called, which can lead to Server-Side Request Forgery (SSRF) or unauthorized access to other GitHub API resources.

🎯 **Impact:** An attacker could potentially read or manipulate data in other GitHub repositories or endpoints by breaking out of the intended API path.

🔧 **Fix:** Added strict regex validation (`/^[a-zA-Z0-9_.-]+$/`) to the `owner` and `repo` URL parameters. The endpoints now return a `400 Bad Request` if invalid characters are provided, ensuring only safe input is passed to the external API.

✅ **Verification:** Tested the backend API endpoints using `npm run test --prefix web-app/server` and confirmed they still pass. Attempting to use malicious characters (e.g., `../`) in the `owner` or `repo` parameters will now correctly result in a 400 error.

---
*PR created automatically by Jules for task [16829044087571549306](https://jules.google.com/task/16829044087571549306) started by @balajirajput96*