### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal and SSRF risk in GitHub API endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -9,3 +9,7 @@
 **Vulnerability:** The FastAPI endpoint `/predict` accepted a `List[float]` without length constraints in `PredictionInput`. A malicious user could send an excessively large list (e.g., millions of items), causing the application to consume excessive memory leading to a Denial of Service (DoS) attack.
 **Learning:** This is a common oversight when defining Pydantic schemas. By default, unbounded iterables (Lists, Dicts, Sets) lack size limits, making endpoints that deserialize large payloads vulnerable to resource exhaustion.
 **Prevention:** Constrain collections and iterables in Pydantic schemas using `Field(..., max_length=N)` where N represents a reasonable, expected upper bound for the business logic.
+## 2024-05-20 - Path Traversal / SSRF in Express URL Parameters
+**Vulnerability:** Unvalidated route parameters (`req.params`) passed directly to external API calls.
+**Learning:** Express decodes URL encoded characters (like %2F) by default. Passing these directly to Axios requests can lead to path traversal and SSRF against the upstream API.
+**Prevention:** Always validate and sanitize route parameters (e.g., using a strict regex for valid characters) before using them to construct external request URLs.

--- a/web-app/server/index.js
+++ b/web-app/server/index.js
@@ -76,8 +76,12 @@ app.get('/api/youtube', (req, res) => res.json({ message: 'YouTube API endpoint'
 app.get('/api/google-drive', (req, res) => res.json({ message: 'Google Drive API endpoint' }));
 
 app.get('/api/github/repos/:owner', async (req, res) => {
+  const { owner } = req.params;
+  if (!/^[a-zA-Z0-9_.-]+$/.test(owner)) {
+    return res.status(400).json({ error: 'Invalid owner parameter' });
+  }
   try {
-    const response = await githubApi.get(`/users/${req.params.owner}/repos`);
+    const response = await githubApi.get(`/users/${owner}/repos`);
     return res.json(response.data);
   } catch (error) {
     return forwardError(res, error, 'Failed to fetch GitHub repositories.');
@@ -85,16 +89,20 @@ app.get('/api/github/repos/:owner', async (req, res) => {
 });
 
 app.post('/api/github/issues/:owner/:repo', async (req, res) => {
+  const { owner, repo } = req.params;
+  if (!/^[a-zA-Z0-9_.-]+$/.test(owner) || !/^[a-zA-Z0-9_.-]+$/.test(repo)) {
+    return res.status(400).json({ error: 'Invalid owner or repo parameter' });
+  }
   const { title, body } = req.body || {};
   if (!title) return res.status(400).json({ error: 'title is required.' });
   try {
-    const response = await githubApi.post(`/repos/${req.params.owner}/${req.params.repo}/issues`, { title, body });
+    const response = await githubApi.post(`/repos/${owner}/${repo}/issues`, { title, body });
     const issue = response.data;
     const channel = '#general';
-    const text = `🚀 New GitHub issue created in ${req.params.owner}/${req.params.repo}:\n<${issue.html_url}|#${issue.number} ${issue.title}>`;
+    const text = `🚀 New GitHub issue created in ${owner}/${repo}:\n<${issue.html_url}|#${issue.number} ${issue.title}>`;
     slackApi.post('/chat.postMessage', { channel, text }).catch(() => {});
     if (process.env.DISCORD_WEBHOOK_URL) {
-      axios.post(process.env.DISCORD_WEBHOOK_URL, { content: `🚀 New GitHub issue created in **${req.params.owner}/${req.params.repo}**: [ #${issue.number} ${issue.title} ](${issue.html_url})` }).catch(() => {});
+      axios.post(process.env.DISCORD_WEBHOOK_URL, { content: `🚀 New GitHub issue created in **${owner}/${repo}**: [ #${issue.number} ${issue.title} ](${issue.html_url})` }).catch(() => {});
     }
     return res.status(201).json(issue);
   } catch (error) {

--- a/web-app/server/package-lock.json
+++ b/web-app/server/package-lock.json
@@ -15,7 +15,7 @@
       },
       "devDependencies": {
         "jest": "^30.2.0",
-        "supertest": "^7.1.4"
+        "supertest": "^7.2.2"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/web-app/server/package.json
+++ b/web-app/server/package.json
@@ -21,6 +21,6 @@
   },
   "devDependencies": {
     "jest": "^30.2.0",
-    "supertest": "^7.1.4"
+    "supertest": "^7.2.2"
   }
 }


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Unvalidated route parameters (`req.params.owner` and `req.params.repo`) were being passed directly to external Axios calls (`githubApi.get` and `githubApi.post`). Since Express automatically decodes URL-encoded characters (like `%2F`), an attacker could craft malicious URLs to perform Path Traversal and Server-Side Request Forgery (SSRF) against the upstream GitHub API.
🎯 **Impact:** An attacker could potentially access unintended endpoints on the GitHub API or cause the application to make arbitrary external requests, leading to data exposure or abuse of backend privileges.
🔧 **Fix:** Added strict regex validation (`/^[a-zA-Z0-9_.-]+$/`) to the `owner` and `repo` route parameters before they are used in external API calls. If the parameters contain invalid characters, the server now returns a 400 Bad Request response.
✅ **Verification:** Verified by running the existing test suite (`npm run test --prefix web-app/server`) and validating the root repository checks (`pnpm lint`, `pnpm test`, `npx tsc --noEmit`, and `pnpm build`). Tests passed successfully.

---
*PR created automatically by Jules for task [13455450431875676308](https://jules.google.com/task/13455450431875676308) started by @balajirajput96*