### PR TITLE
🎨 Palette: Improve accessibility and usability of terminal prompt symbols

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2024-08-26 - [UX] Decorative Prompt Symbols in Terminal UIs
+**Learning:** Terminal UI components often include decorative prompt symbols (like `~` and `$`) and blinking cursors. If these are not hidden from screen readers using `aria-hidden="true"`, they create redundant noise. Furthermore, users often try to copy the commands from these terminal previews; if prompt symbols are selectable, they get accidentally copied along with the command text, leading to invalid commands when pasted into a real terminal.
+**Action:** Always add `aria-hidden="true"` and `userSelect: 'none'` (or `user-select: none` in CSS) to decorative terminal prompt symbols to ensure they are ignored by screen readers and not accidentally copied by users. Add `aria-hidden="true"` to decorative cursor elements.

--- a/src/components/landing/TerminalPreview.tsx
+++ b/src/components/landing/TerminalPreview.tsx
@@ -37,13 +37,13 @@ const TERMINAL_HEADER = (
 // objects on every frame, saving CPU cycles.
 const TERMINAL_PROMPT = (
   <>
-    <span style={{ color: 'var(--primary-accent)' }}>~</span>
-    <span style={{ color: 'var(--secondary-accent)' }}>$</span>
+    <span aria-hidden="true" style={{ color: 'var(--primary-accent)', userSelect: 'none' }}>~</span>
+    <span aria-hidden="true" style={{ color: 'var(--secondary-accent)', userSelect: 'none' }}>$</span>
   </>
 );
 
 const TERMINAL_CURSOR = (
-  <span className="cursor-blink" style={{
+  <span aria-hidden="true" className="cursor-blink" style={{
     display: 'inline-block',
     width: '8px',
     height: '15px',


### PR DESCRIPTION
💡 **What**: Added `aria-hidden="true"` and `userSelect: 'none'` to the terminal prompt symbols (`~` and `$`), and `aria-hidden="true"` to the blinking cursor in the `TerminalPreview` component.
🎯 **Why**: Decorative prompt symbols and cursors create redundant noise for screen reader users if not explicitly hidden. Furthermore, when users attempt to copy commands from the terminal preview, they often accidentally copy the prompt characters along with the command text, leading to invalid commands when pasted. Making the prompt symbols unselectable improves usability.
📸 **Before/After**: Visually, the component remains identical. However, the text selection behavior is improved.
♿ **Accessibility**: Improved screen reader experience by hiding decorative visual elements that do not convey functional information.

---
*PR created automatically by Jules for task [6972967586885916622](https://jules.google.com/task/6972967586885916622) started by @balajirajput96*