### PR TITLE
🎨 Palette: Improve terminal prompt accessibility and copy UX

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-08-27 - Terminal Prompt Accessibility and Selection UX
+**Learning:** Terminal UI components often use decorative symbols like `~` and `$` to simulate prompts. However, if left unchecked, screen readers announce these redundantly, and users accidentally select them when trying to copy terminal commands.
+**Action:** Always add `aria-hidden="true"` to hide decorative prompt symbols from screen readers, and apply `userSelect: 'none'` to prevent accidental highlighting during command copy-pasting.

--- a/src/components/landing/TerminalPreview.tsx
+++ b/src/components/landing/TerminalPreview.tsx
@@ -37,13 +37,13 @@ const TERMINAL_HEADER = (
 // objects on every frame, saving CPU cycles.
 const TERMINAL_PROMPT = (
   <>
-    <span style={{ color: 'var(--primary-accent)' }}>~</span>
-    <span style={{ color: 'var(--secondary-accent)' }}>$</span>
+    <span aria-hidden="true" style={{ color: 'var(--primary-accent)', userSelect: 'none' }}>~</span>
+    <span aria-hidden="true" style={{ color: 'var(--secondary-accent)', userSelect: 'none' }}>$</span>
   </>
 );
 
 const TERMINAL_CURSOR = (
-  <span className="cursor-blink" style={{
+  <span aria-hidden="true" className="cursor-blink" style={{
     display: 'inline-block',
     width: '8px',
     height: '15px',


### PR DESCRIPTION
* 💡 What: Added `aria-hidden="true"` and `userSelect: 'none'` to the decorative terminal prompt characters (`~`, `$`) and cursor in the `TerminalPreview` component.
* 🎯 Why: To prevent screen readers from redundantly announcing these decorative symbols and to stop users from accidentally selecting and copying the prompt characters when copying terminal commands.
* 📸 Before/After: Before, the prompt symbols and cursor were selectable by dragging over them and visible to screen readers as text content. After, they are skipped by screen readers and unselectable, leading to cleaner command copying.
* ♿ Accessibility: Improved screen reader experience by explicitly hiding decorative text elements (`~`, `$`, cursor) from the accessibility tree, leaving only the actual command and output visible to assistive technologies.

---
*PR created automatically by Jules for task [18166039205265867599](https://jules.google.com/task/18166039205265867599) started by @balajirajput96*