### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal in GitHub API endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -9,3 +9,7 @@
 **Vulnerability:** The FastAPI endpoint `/predict` accepted a `List[float]` without length constraints in `PredictionInput`. A malicious user could send an excessively large list (e.g., millions of items), causing the application to consume excessive memory leading to a Denial of Service (DoS) attack.
 **Learning:** This is a common oversight when defining Pydantic schemas. By default, unbounded iterables (Lists, Dicts, Sets) lack size limits, making endpoints that deserialize large payloads vulnerable to resource exhaustion.
 **Prevention:** Constrain collections and iterables in Pydantic schemas using `Field(..., max_length=N)` where N represents a reasonable, expected upper bound for the business logic.
+## 2024-10-27 - Mitigate Path Traversal and SSRF in URL Parameters
+**Vulnerability:** The Express backend `web-app/server/index.js` automatically decodes URL parameters (like `%2F` to `/`). When these parameters (like `owner` and `repo`) are used directly to construct external API requests without validation, it allows path traversal and SSRF attacks.
+**Learning:** URL parameters provided by the user should never be trusted and directly injected into backend requests, even if they appear innocuous. Express's automatic decoding of URL-encoded characters exacerbates this risk if characters like `/` or `.` are injected.
+**Prevention:** Strictly validate user-provided URL parameters using regular expressions (e.g., `/^[a-zA-Z0-9_.-]+$/`) before using them to build external requests or system paths.

--- a/web-app/server/index.js
+++ b/web-app/server/index.js
@@ -76,8 +76,12 @@ app.get('/api/youtube', (req, res) => res.json({ message: 'YouTube API endpoint'
 app.get('/api/google-drive', (req, res) => res.json({ message: 'Google Drive API endpoint' }));
 
 app.get('/api/github/repos/:owner', async (req, res) => {
+  const owner = req.params.owner;
+  if (!/^[a-zA-Z0-9_.-]+$/.test(owner)) {
+    return res.status(400).json({ error: 'Invalid owner parameter.' });
+  }
   try {
-    const response = await githubApi.get(`/users/${req.params.owner}/repos`);
+    const response = await githubApi.get(`/users/${owner}/repos`);
     return res.json(response.data);
   } catch (error) {
     return forwardError(res, error, 'Failed to fetch GitHub repositories.');
@@ -85,16 +89,21 @@ app.get('/api/github/repos/:owner', async (req, res) => {
 });
 
 app.post('/api/github/issues/:owner/:repo', async (req, res) => {
+  const owner = req.params.owner;
+  const repo = req.params.repo;
+  if (!/^[a-zA-Z0-9_.-]+$/.test(owner) || !/^[a-zA-Z0-9_.-]+$/.test(repo)) {
+    return res.status(400).json({ error: 'Invalid owner or repo parameter.' });
+  }
   const { title, body } = req.body || {};
   if (!title) return res.status(400).json({ error: 'title is required.' });
   try {
-    const response = await githubApi.post(`/repos/${req.params.owner}/${req.params.repo}/issues`, { title, body });
+    const response = await githubApi.post(`/repos/${owner}/${repo}/issues`, { title, body });
     const issue = response.data;
     const channel = '#general';
-    const text = `🚀 New GitHub issue created in ${req.params.owner}/${req.params.repo}:\n<${issue.html_url}|#${issue.number} ${issue.title}>`;
+    const text = `🚀 New GitHub issue created in ${owner}/${repo}:\n<${issue.html_url}|#${issue.number} ${issue.title}>`;
     slackApi.post('/chat.postMessage', { channel, text }).catch(() => {});
     if (process.env.DISCORD_WEBHOOK_URL) {
-      axios.post(process.env.DISCORD_WEBHOOK_URL, { content: `🚀 New GitHub issue created in **${req.params.owner}/${req.params.repo}**: [ #${issue.number} ${issue.title} ](${issue.html_url})` }).catch(() => {});
+      axios.post(process.env.DISCORD_WEBHOOK_URL, { content: `🚀 New GitHub issue created in **${owner}/${repo}**: [ #${issue.number} ${issue.title} ](${issue.html_url})` }).catch(() => {});
     }
     return res.status(201).json(issue);
   } catch (error) {


### PR DESCRIPTION
🚨 **Severity:** HIGH

💡 **Vulnerability:** The Express backend endpoints for proxying GitHub API requests (`/api/github/repos/:owner` and `/api/github/issues/:owner/:repo`) directly passed URL parameters `req.params.owner` and `req.params.repo` into `axios` HTTP requests. Express automatically decodes URL-encoded parameters (e.g., `%2F` becomes `/`). Without validation, this allowed attackers to inject characters like `/` or `..` enabling path traversal and SSRF against the backend GitHub requests.

🎯 **Impact:** An attacker could craft a malicious URL parameter that breaks out of the intended GitHub API endpoint structure. This could allow them to interact with other unintended GitHub API endpoints or potentially make unauthorized requests using the server's context, depending on the internal configuration and `githubApi` base URL configuration.

🔧 **Fix:** Implemented rigorous input validation using the regex `/^[a-zA-Z0-9_.-]+$/` for both `owner` and `repo` parameters before constructing the downstream `githubApi` requests. If the inputs contain any characters outside of the safe list (e.g., `/`, `?`, `#`), a `400 Bad Request` is returned immediately.

✅ **Verification:**
1. Ran `npm run test --prefix web-app/server` to ensure no backend routing functionality was broken. All 6 tests passed.
2. Manually verified the regex behaves correctly by reviewing the changes.
3. Ran root CI verification checks `pnpm lint`, `pnpm test`, and `pnpm build` which all succeeded.
4. Appended the required security entry to `.jules/sentinel.md` detailing the vulnerability, learning, and prevention strategy.

---
*PR created automatically by Jules for task [15686996008015824085](https://jules.google.com/task/15686996008015824085) started by @balajirajput96*