### PR TITLE
🎨 Palette: Keyboard focus parity for Feature Cards

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-08-27 - Terminal Prompt Accessibility and Selection UX
 **Learning:** Terminal UI components often use decorative symbols like `~` and `$` to simulate prompts. However, if left unchecked, screen readers announce these redundantly, and users accidentally select them when trying to copy terminal commands.
 **Action:** Always add `aria-hidden="true"` to hide decorative prompt symbols from screen readers, and apply `userSelect: 'none'` to prevent accidental highlighting during command copy-pasting.
+
+## 2024-09-12 - Keyboard focus parity on hover effects
+**Learning:** Adding hover effects (`whileHover` in Framer Motion or `:hover` in CSS) to cards and containers visually enhances interactions, but leaves keyboard users without equivalent visual feedback.
+**Action:** When adding hover states for interactivity/delight to non-interactive container elements, apply `tabIndex={0}` and equivalent focus states (`whileFocus` and `:focus-visible`) to maintain accessibility parity.

--- a/src/components/landing/FeatureCard.tsx
+++ b/src/components/landing/FeatureCard.tsx
@@ -15,6 +15,8 @@ export function FeatureCard({ icon, title, description, index }: FeatureCardProp
       viewport={{ once: true, margin: "-50px" }}
       transition={{ duration: 0.5, delay: index * 0.1 }}
       whileHover={{ y: -5, boxShadow: '0 10px 40px var(--shadow-color)' }}
+      whileFocus={{ y: -5, boxShadow: '0 10px 40px var(--shadow-color)' }}
+      tabIndex={0}
       style={{
         background: 'var(--surface-color)',
         border: '1px solid var(--border-color)',
@@ -58,7 +60,8 @@ export function FeatureCard({ icon, title, description, index }: FeatureCardProp
 
       <style>
         {`
-          div:hover > .card-glow {
+          div:hover > .card-glow,
+          div:focus-visible > .card-glow {
             opacity: 0.1;
           }
         `}


### PR DESCRIPTION
**What:** 
Added `whileFocus` state and `tabIndex={0}` to Feature Cards in `src/components/landing/FeatureCard.tsx`. Also added a `focus-visible` styling selector for the card's internal glow effect.

**Why:** 
Previously, the Feature Cards had a visual lifting animation and a subtle glow when hovered with a mouse pointer. However, keyboard users navigating via the Tab key were entirely excluded from this interactive micro-delight.

**Before/After:** 
Before: Tabbing onto the card did nothing.
After: Tabbing onto the card triggers the same lift and glow effects as mouse hover. The focus state is visible alongside the standard focus outline. (Refer to verification videos/screenshots in the workflow logs).

**Accessibility:** 
Improved keyboard interaction parity. Ensuring focus states visually match hover states is crucial for inclusive design, giving keyboard users the same feedback and aesthetic experience as pointer users.

---
*PR created automatically by Jules for task [166627967152238772](https://jules.google.com/task/166627967152238772) started by @balajirajput96*